### PR TITLE
Fix: sign-in button appearance on mobile

### DIFF
--- a/client/passwordless.css
+++ b/client/passwordless.css
@@ -34,6 +34,9 @@
   border: 2px solid var(--passwordless-primary);
   min-height: 2rem;
 }
+.passwordless-button-sign-in {
+  width: 18rem;
+}
 
 .passwordless-button:hover,
 .passwordless-button:focus {
@@ -184,9 +187,8 @@
 }
 
 .passwordless-flex-vertical-buttons {
-  align-items: stretch;
+  align-items: center;
   flex-direction: column;
-  padding: 0px 70px;
 }
 
 .passwordless-grid {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* On mobile the sign-in buttons look proper now:
<img width="371" alt="image" src="https://user-images.githubusercontent.com/6275520/236481245-507b1217-9456-4d5d-bfd1-6783ed7db44a.png">


Before:
<img width="368" alt="image" src="https://user-images.githubusercontent.com/6275520/236480923-87552d04-a0a7-447e-85fb-eff89529b120.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
