### PR TITLE
Fix: allow Face Touch option also with just a Security Key

### DIFF
--- a/client/react/components.tsx
+++ b/client/react/components.tsx
@@ -75,7 +75,6 @@ export const Passwordless = ({
     tokens,
     tokensParsed,
     signOut,
-    userVerifyingPlatformAuthenticatorAvailable,
     toggleShowAuthenticatorManager,
     showAuthenticatorManager,
   } = usePasswordless();
@@ -231,10 +230,6 @@ export const Passwordless = ({
 
   const user = lastSignedInUsers.at(0);
   const { email, credentials, useFido } = user ?? {};
-  const showFaceTouchOption =
-    useFido === "YES" &&
-    (userVerifyingPlatformAuthenticatorAvailable ||
-      fido2.authenticatorSelection?.userVerification !== "required");
 
   return (
     <FlexContainer brand={brand}>
@@ -243,7 +238,7 @@ export const Passwordless = ({
           <div>
             <div className="passwordless-email-title">{email}</div>
             <p className="passwordless-flex passwordless-flex-vertical-buttons">
-              {showFaceTouchOption && (
+              {useFido === "YES" && (
                 <button
                   className="passwordless-button passwordless-button-sign-in"
                   onClick={() => {
@@ -270,7 +265,7 @@ export const Passwordless = ({
               )}
               <button
                 className={`passwordless-button passwordless-button-sign-in ${
-                  showFaceTouchOption ? "passwordless-button-outlined" : ""
+                  useFido === "YES" ? "passwordless-button-outlined" : ""
                 }`}
                 onClick={() => !busy && requestSignInLink(email)}
                 disabled={busy}

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -604,7 +604,6 @@ function _useLocalUserCache() {
     creatingCredential,
     fido2Credentials,
     signingInStatus,
-    userVerifyingPlatformAuthenticatorAvailable,
   } = usePasswordless();
   const idToken = tokensParsed?.idToken;
   const hasFido2Credentials = fido2Credentials && !!fido2Credentials.length;
@@ -681,16 +680,6 @@ function _useLocalUserCache() {
       if (!fido2) {
         throw new Error("Missing Fido2 config");
       }
-      if (
-        (!fido2.authenticatorSelection?.userVerification ||
-          fido2.authenticatorSelection.userVerification === "required") &&
-        !userVerifyingPlatformAuthenticatorAvailable
-      ) {
-        if (user.useFido === "NO") {
-          return "NO";
-        }
-        return "INDETERMINATE";
-      }
       if (hasFido2Credentials === undefined) {
         return "INDETERMINATE";
       }
@@ -716,7 +705,6 @@ function _useLocalUserCache() {
       hasFido2Credentials,
       fidoPreferenceOverride,
       justSignedInWithMagicLink,
-      userVerifyingPlatformAuthenticatorAvailable,
     ]
   );
 


### PR DESCRIPTION
*Issue #, if available:* #30

*Description of changes:* The "Sign in with Face/Touch" button should be shown also if the user does *not* have a platform authenticator available but has a registered security key (e.g. via USB). Therefore we no longer check that `userVerifyingPlatformAuthenticatorAvailable === true`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
