### PR TITLE
chore(docs): add ddb to magic link diagram

### DIFF
--- a/MAGIC-LINKS.md
+++ b/MAGIC-LINKS.md
@@ -153,6 +153,7 @@ sequenceDiagram
     participant CA as CreateAuthChallenge
     participant VA as VerifyAnswer
     participant KMS as AWS KMS
+    participant DDB as DynamoDB
     User->>BJS: Open magic link
     activate BJS
     activate User
@@ -176,6 +177,10 @@ sequenceDiagram
     Activate C
     C->>VA: Invoke
     Activate VA
+    VA->>DDB: Delete magic-link metadata w/ condition
+    Activate DDB
+    DDB->>VA: Deleted record (w/ KMS Key ID), exception, or null
+    Deactivate DDB
     VA->>KMS: Download public key
     Activate KMS
     KMS->>VA: Public key


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update the magic link sequence diagram for sign in using a different browser to add DDB

I believe the current sequence diagram for sign in using a different browser is missing the DDB component. Unless I am mistaken, the record is fetched/deleted from DDB for the different browser scenario as well.
- [Current diagram](https://github.com/aws-samples/amazon-cognito-passwordless-auth/blob/main/MAGIC-LINKS.md#complete-sign-in-different-browser) 
- [Updated diagram](https://github.com/Jordan-Nelson/amazon-cognito-passwordless-auth/blob/29bd095ba49a1d8a8ef58eb12a9c37a27ef32ca6/MAGIC-LINKS.md#complete-sign-in-different-browser)
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
