### PR TITLE
docs(react-native): properly indicate how to configure the client

### DIFF
--- a/client/react/README-REACT-NATIVE.md
+++ b/client/react/README-REACT-NATIVE.md
@@ -85,12 +85,11 @@ To use the library, you need to first import, wrap your app with the Passwordles
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import {
   PasswordlessContextProvider,
-  usePasswordless,
+  Passwordless,
 } from "amazon-cognito-passwordless-auth";
 
 function App() {
-  const { configure } = usePasswordless();
-  configure({
+  Passwordless.configure({
     cognitoIdpEndpoint: "<URL_TO_YOUR_COGNITO_PROXY_API>",
     clientId: "<COGNITO_CLIENT_ID>",
     userPoolId: "<COGNITO_USER_POOL_ID>",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
React Native docs were outdated since configure is not coming as part of the hook


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
