### PR TITLE
Clean unused d.ts file from dist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,27 @@ jobs:
         with:
           node-version: "18"
       - name: install
+        run: npm install
+      - name: lint
+        run: npx eslint --ignore-pattern end-to-end-example .
+      - name: prettier
+        run: npx prettier -c .
+      - name: dist
+        run: npm run dist
+      - name: cdk usage smoke test
         run: |
-          npm install
-      - name: test-create-dist
+          cd end-to-end-example/cdk
+          npm run install-passwordless-local
+          echo 'CDK_STACK_SES_FROM_ADDRESS=no-reply@example.com' > .env.local
+          echo 'CDK_STACK_NAME=test' > .env.local
+          npx cdk synth
+      - name: client usage smoke test
         run: |
-          npx prettier -c .
-          npx eslint --ignore-pattern end-to-end-example .
-          npm run dist
+          cd end-to-end-example/client
+          npm run install-passwordless-local
+          echo 'VITE_COGNITO_IDP_ENDPOINT=eu-west-1' > .env.local
+          echo 'VITE_CLIENT_ID=testclientid' > .env.local
+          echo 'VITE_FIDO2_BASE_URL=https://example.org.fido2/' > .env.local
+          npm run build
+      - name: lint end-to-end-example
+        run: npx eslint end-to-end-example

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "main": "dist/client/index.js",
   "react-native": "dist/client/react/react-native.js",
   "scripts": {
-    "gen-types:cdk": "tsc --project cdk/lib/tsconfig.json --declarationDir . --declaration --emitDeclarationOnly && mv ./cognito-passwordless.d.ts cdk.d.ts && tsc --project cdk/custom-auth/tsconfig.json --declarationDir ./custom-auth --declaration --emitDeclarationOnly",
-    "gen-types:client": "tsc --project client/tsconfig.json --declarationDir . --declaration --emitDeclarationOnly",
+    "gen-types:cdk": "rm -rf custom-auth && tsc --project cdk/lib/tsconfig.json --declarationDir . --declaration --emitDeclarationOnly && mv ./cognito-passwordless.d.ts cdk.d.ts && tsc --project cdk/custom-auth/tsconfig.json --declarationDir ./custom-auth --declaration --emitDeclarationOnly",
+    "gen-types:client": "rm -rf react && tsc --project client/tsconfig.json --declarationDir . --declaration --emitDeclarationOnly",
     "gen-types": "npm run gen-types:cdk && npm run gen-types:client",
     "clear-d-ts": "find . -type d -name node_modules -prune -o -name '*.d.ts' -print | xargs rm",
     "dist:client": "rm -rf dist/client && npm run gen-types:client && cd client && npx tsc --outdir ../dist/client && cp *.css ../dist/client && node ../dist-create-package.cjs client module",
@@ -117,7 +117,21 @@
     "dist",
     "react",
     "custom-auth",
-    "*.d.ts"
+    "cdk.d.ts",
+    "cognito-api.d.ts",
+    "common.d.ts",
+    "config.d.ts",
+    "fido2.d.ts",
+    "index.d.ts",
+    "jwt-model.d.ts",
+    "magic-link.d.ts",
+    "model.d.ts",
+    "plaintext.d.ts",
+    "refresh.d.ts",
+    "sms-otp-stepup.d.ts",
+    "srp.d.ts",
+    "storage.d.ts",
+    "util.d.ts"
   ],
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.290.0",


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Noticed while browsing https://www.unpkg.com/browse/amazon-cognito-passwordless-auth@0.6.6/ that there's a d.ts file in there that is an old leftover from a local experiment (`temporary-aws-credentials.d.ts`). Therefore made some changes to package.json to prevent this in the future. Decided to be exact and list all the d.ts files we want in the NPM dist. To prevent missing d.ts files that we might add in the future, I added smoke tests to our GitHub workflow, to make sure our library is able to install, that cdk synth works, and that building the client works.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
