### PR TITLE
Allow magic links that match allowedOrigins regardless of the path in the magic link

### DIFF
--- a/cdk/custom-auth/fido2-credentials-api.ts
+++ b/cdk/custom-auth/fido2-credentials-api.ts
@@ -46,7 +46,7 @@ const relyingPartyName = process.env.RELYING_PARTY_NAME!;
 const allowedOrigins =
   process.env.ALLOWED_ORIGINS?.split(",")
     .map((href) => new URL(href))
-    .map((url) => url.href) ?? [];
+    .map((url) => url.origin) ?? [];
 if (!allowedOrigins.length)
   throw new Error("Environment variable ALLOWED_ORIGINS is not set");
 const authenticatorRegistrationTimeout = Number(
@@ -560,7 +560,7 @@ async function handleCredentialsResponse(
     throw new UserFacingError("Challenge not found");
   }
   logger.debug("Challenge found:", JSON.stringify(storedChallenge));
-  if (!allowedOrigins.includes(new URL(clientData.origin).href)) {
+  if (!allowedOrigins.includes(new URL(clientData.origin).origin)) {
     throw new UserFacingError(
       `Invalid clientData origin: ${clientData.origin}`
     );

--- a/cdk/custom-auth/fido2.ts
+++ b/cdk/custom-auth/fido2.ts
@@ -41,7 +41,7 @@ let config = {
   dynamoDbAuthenticatorsTableName: process.env.DYNAMODB_AUTHENTICATORS_TABLE,
   allowedOrigins: process.env.ALLOWED_ORIGINS?.split(",")
     .map((href) => new URL(href))
-    .map((url) => url.href),
+    .map((url) => url.origin),
   allowedRelyingPartyIds: process.env.ALLOWED_RELYING_PARTY_IDS?.split(","),
   relyingPartyId: process.env.RELYING_PARTY_ID,
   userVerification: process.env
@@ -269,7 +269,7 @@ export async function verifyChallenge({
     );
   }
   if (
-    !requireConfig("allowedOrigins").includes(new URL(clientData.origin).href)
+    !requireConfig("allowedOrigins").includes(new URL(clientData.origin).origin)
   ) {
     throw new Error(`Invalid clientData origin: ${clientData.origin}`);
   }

--- a/cdk/custom-auth/magic-link.ts
+++ b/cdk/custom-auth/magic-link.ts
@@ -52,7 +52,7 @@ let config = {
   /** The origins that are allowed to be used in the Magic Links */
   allowedOrigins: process.env.ALLOWED_ORIGINS?.split(",")
     .map((href) => new URL(href))
-    .map((url) => url.href),
+    .map((url) => url.origin),
   /** The e-mail address that Magic Links will be sent from */
   sesFromAddress: process.env.SES_FROM_ADDRESS,
   /** The Amazon SES region */
@@ -119,7 +119,7 @@ export async function addChallengeToEvent(
   const redirectUri = event.request.clientMetadata?.redirectUri;
   if (
     !redirectUri ||
-    !requireConfig("allowedOrigins").includes(new URL(redirectUri).href)
+    !requireConfig("allowedOrigins").includes(new URL(redirectUri).origin)
   ) {
     throw new UserFacingError(`Invalid redirectUri: ${redirectUri}`);
   }

--- a/cdk/lib/cognito-passwordless.ts
+++ b/cdk/lib/cognito-passwordless.ts
@@ -46,7 +46,16 @@ export class Passwordless extends Construct {
       userPoolProps?: Partial<cdk.aws_cognito.UserPoolProps>;
       /** If you don't provide an existing User Pool Client, one will be created for you. Pass any properties you want for it, these will be merged with properties from this solution */
       userPoolClientProps?: Partial<cdk.aws_cognito.UserPoolClientOptions>;
-      /** The origins (URLs) where you will be hosting your Web app on (required for FIDO2 and Magic Links) */
+      /**
+       * The origins where you will be hosting your Web app on: scheme, hostname, and optionally port.
+       * Do not include path as it will be ignored. The wildcard (*) is not supported.
+       *
+       * Example value: https://subdomain.example.org
+       *
+       * This property is required when using FIDO2 or Magic Links:
+       * - For FIDO2 it is validated that the clientData.origin matches one of the allowedOrigins. Also, allowedOrigins is used as CORS origin setting on the FIDO2 credentials API.
+       * - For Magic Links it is validated that the redirectUri (without path) in each Magic Link matches one of the allowedOrigins.
+       */
       allowedOrigins?: string[];
       /** Enable sign-in with FIDO2 by providing this config object */
       fido2?: {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This change allows Magic Links to use dynamic paths, that are not know at the time the CDK stack is deployed. Also this fixes an issue that would have occured for FIDO2 with origin mismatches, if a path was specified.

__Previous behavior__:

- With the setting `allowedOrigins: ["https://example.org"]` a magic link with redirect uri `https://example.org/somepath` would be rejected.
- A path could be included in `allowedOrigins`: `["https://example.org/somepath"]`. Magic Links would need to match this path. Note that this would cause issues for the FIDO2 credentials API as an origin with a path is not a valid CORS origin. CORS origins do not have a path, nor do the origins in FIDO2 clientData. See also: https://datatracker.ietf.org/doc/html/rfc6454

__New behavior__:

With the setting `allowedOrigins: ["https://example.org"]` a magic link with redirect uri `https://example.org/somepath` will work (if otherwise all valid).
- A path should not be included: `allowedOrigins: ["https://example.org"]`
- Even if a path is included, it will be ignored. No issues for FIDO2 can occur.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
