### PR TITLE
Add redirectUri option to requestSignInLink hook

### DIFF
--- a/client/magic-link.ts
+++ b/client/magic-link.ts
@@ -68,7 +68,8 @@ export const requestSignInLink = ({
         },
         clientMetadata: {
           signInMethod: "MAGIC_LINK",
-          redirectUri: redirectUri || currentBrowserLocationWithoutFragmentIdentifier(),
+          redirectUri:
+            redirectUri || currentBrowserLocationWithoutFragmentIdentifier(),
           alreadyHaveMagicLink: "no",
         },
         session: res.Session,

--- a/client/react/README-REACT.md
+++ b/client/react/README-REACT.md
@@ -294,8 +294,8 @@ export default function YourComponent() {
       // automatically (if you've loaded this library), and sign the user in
       // supply an optional redirectUri as the second argument to specify where
       // in your application you'd like the user to be directed to after signing in.
-      const username = event.currentTarget.username.value
-      const redirectUri = "https://example.com/article/45"
+      const username = event.currentTarget.username.value;
+      const redirectUri = "https://example.com/article/45";
       requestSignInLink(username, redirectUri);
       event.preventDefault();
     }}

--- a/client/react/README-REACT.md
+++ b/client/react/README-REACT.md
@@ -292,9 +292,11 @@ export default function YourComponent() {
       // Request a magic link to be e-mailed to the user.
       // When the user clicks on the link, your web app will open and parse the link
       // automatically (if you've loaded this library), and sign the user in
-      requestSignInLink({
-        username: event.currentTarget.username.value,
-      });
+      // supply an optional redirectUri as the second argument to specify where
+      // in your application you'd like the user to be directed to after signing in.
+      const username = event.currentTarget.username.value
+      const redirectUri = "https://example.com/article/45"
+      requestSignInLink(username, redirectUri);
       event.preventDefault();
     }}
   >

--- a/client/react/README-REACT.md
+++ b/client/react/README-REACT.md
@@ -291,12 +291,13 @@ export default function YourComponent() {
     onSubmit={(event) => {
       // Request a magic link to be e-mailed to the user.
       // When the user clicks on the link, your web app will open and parse the link
-      // automatically (if you've loaded this library), and sign the user in
-      // supply an optional redirectUri as the second argument to specify where
+      // automatically (if you've loaded this library), and sign the user in.
+      // Supply an optional redirectUri as the second argument to specify where
       // in your application you'd like the user to be directed to after signing in.
-      const username = event.currentTarget.username.value;
-      const redirectUri = "https://example.com/article/45";
-      requestSignInLink(username, redirectUri);
+      requestSignInLink({
+        username: event.currentTarget.username.value,
+        redirectUri: "https://example.com/article/45",
+      });
       event.preventDefault();
     }}
   >

--- a/client/react/components.tsx
+++ b/client/react/components.tsx
@@ -93,7 +93,7 @@ export const Passwordless = ({
   }, [lastSignedInUsers]);
 
   function signInWithMagicLinkOrFido2(username: string) {
-    requestSignInLink(username).signInLinkRequested.catch((err) => {
+    requestSignInLink({ username }).signInLinkRequested.catch((err) => {
       if (
         err instanceof Error &&
         err.message.toLowerCase().includes("you must sign-in with fido2")
@@ -257,7 +257,7 @@ export const Passwordless = ({
                 className={`passwordless-button passwordless-button-sign-in ${
                   useFido === "YES" ? "passwordless-button-outlined" : ""
                 }`}
-                onClick={() => !busy && requestSignInLink(email)}
+                onClick={() => !busy && requestSignInLink({ username: email })}
                 disabled={busy}
               >
                 <div className="passwordless-flex">

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -446,7 +446,13 @@ function _usePasswordless() {
       return signingOut;
     },
     /** Request a sign-in link ("magic link") to be sent to the user's e-mail address */
-    requestSignInLink: (username: string, redirectUri?: string) => {
+    requestSignInLink: ({
+      username,
+      redirectUri,
+    }: {
+      username: string;
+      redirectUri?: string;
+    }) => {
       setLastError(undefined);
       const requesting = requestSignInLink({
         usernameOrAlias: username,


### PR DESCRIPTION
*Description of changes:*

This is a small non-breaking change to help with developers who want to implement a custom login form. It adds the ability to supply a `redirectUri` along with an email address to the `requestSignInLink` hook. That way developers can allow deep linking into their applications when the user clicks the magic link to verify, rather than the default behavior of re-directing them back to the login page (or wherever the hook was called).

e.g.

```JavaScript
const { requestSignInLink } = usePasswordless()
//some code
requestSignInLink("email@example.com", "https://example.com/article/45/")
```

I also fixed a small error in the documentation where it suggested you call the `requestSignInLink` with `requestSignInLink({username: event.currentTarget.username.value})`, while the hook actually expects a `string`