### PR TITLE
Refactor/username

### DIFF
--- a/client/cognito-api.ts
+++ b/client/cognito-api.ts
@@ -339,6 +339,9 @@ export async function signUp({
   validationData,
   abort,
 }: {
+  /**
+   * Username, or alias (e-mail, phone number)
+   */
   username: string;
   password: string;
   userAttributes?: { name: string; value: string }[];
@@ -531,6 +534,9 @@ export async function handleAuthResponse({
   abort,
 }: {
   authResponse: ChallengeResponse | AuthenticatedResponse;
+  /**
+   * Username, or alias (e-mail, phone number)
+   */
   username: string;
   smsMfaCode?: () => Promise<string>;
   newPassword?: () => Promise<string>;

--- a/client/cognito-api.ts
+++ b/client/cognito-api.ts
@@ -535,7 +535,7 @@ export async function handleAuthResponse({
 }: {
   authResponse: ChallengeResponse | AuthenticatedResponse;
   /**
-   * Username, or alias (e-mail, phone number)
+   * Username (not alias)
    */
   username: string;
   smsMfaCode?: () => Promise<string>;

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -455,6 +455,9 @@ export function authenticateWithFido2({
   clientMetadata,
   credentialGetter = fido2getCredential,
 }: {
+  /**
+   * Username, or alias (e-mail, phone number)
+   */
   username: string;
   credentials?: { id: string; transports?: AuthenticatorTransport[] }[];
   tokensCb?: (tokens: TokensFromSignIn) => void | Promise<void>;

--- a/client/magic-link.ts
+++ b/client/magic-link.ts
@@ -31,11 +31,11 @@ import { configure } from "./config.js";
 import { CognitoIdTokenPayload } from "./jwt-model.js";
 
 export const requestSignInLink = ({
-  usernameOrAlias,
+  username,
   currentStatus,
   statusCb,
 }: {
-  usernameOrAlias: string;
+  username: string;
   currentStatus?: BusyState | IdleState;
   statusCb?: (status: BusyState | IdleState) => void;
 }) => {
@@ -52,17 +52,17 @@ export const requestSignInLink = ({
       let res = await initiateAuth({
         authflow: "CUSTOM_AUTH",
         authParameters: {
-          USERNAME: usernameOrAlias,
+          USERNAME: username,
         },
         abort: abort.signal,
       });
       assertIsChallengeResponse(res);
-      const username = res.ChallengeParameters.USERNAME;
+      username = res.ChallengeParameters.USERNAME; // switch to non-alias if necessary
       res = await respondToAuthChallenge({
         challengeName: "CUSTOM_CHALLENGE",
         challengeResponses: {
           ANSWER: "__dummy__",
-          USERNAME: usernameOrAlias,
+          USERNAME: username,
         },
         clientMetadata: {
           signInMethod: "MAGIC_LINK",
@@ -165,14 +165,14 @@ function assertIsMessage(
 }
 
 async function authenticateWithSignInLink({
-  usernameOrAlias,
+  username,
   fragmentIdentifier,
   currentStatus,
   clientMetadata,
   session,
   abort,
 }: {
-  usernameOrAlias: string;
+  username: string;
   fragmentIdentifier: string;
   currentStatus?: BusyState | IdleState;
   clientMetadata?: Record<string, string>;
@@ -186,18 +186,15 @@ async function authenticateWithSignInLink({
     );
   }
   session ??=
-    (await storage.getItem(
-      `Passwordless.${clientId}.${usernameOrAlias}.session`
-    )) ?? undefined;
-  await storage.removeItem(
-    `Passwordless.${clientId}.${usernameOrAlias}.session`
-  );
+    (await storage.getItem(`Passwordless.${clientId}.${username}.session`)) ??
+    undefined;
+  await storage.removeItem(`Passwordless.${clientId}.${username}.session`);
   if (!session) {
     debug?.(`Invoking initiateAuth ...`);
     const initAuthResponse = await initiateAuth({
       authflow: "CUSTOM_AUTH",
       authParameters: {
-        USERNAME: usernameOrAlias,
+        USERNAME: username,
       },
       abort,
     });
@@ -212,7 +209,7 @@ async function authenticateWithSignInLink({
     challengeName: "CUSTOM_CHALLENGE",
     challengeResponses: {
       ANSWER: fragmentIdentifier,
-      USERNAME: usernameOrAlias,
+      USERNAME: username,
     },
     clientMetadata: {
       ...clientMetadata,
@@ -259,7 +256,7 @@ export const signInWithLink = (props?: {
     statusCb?.("SIGNING_IN_WITH_LINK");
     try {
       const tokens = await authenticateWithSignInLink({
-        usernameOrAlias: params.username,
+        username: params.username,
         fragmentIdentifier: params.fragmentIdentifier,
         session: props?.session,
         abort: abort.signal,

--- a/client/magic-link.ts
+++ b/client/magic-link.ts
@@ -36,6 +36,9 @@ export const requestSignInLink = ({
   currentStatus,
   statusCb,
 }: {
+  /**
+   * Username, or alias (e-mail, phone number)
+   */
   username: string;
   redirectUri?: string;
   currentStatus?: BusyState | IdleState;
@@ -175,6 +178,9 @@ async function authenticateWithSignInLink({
   session,
   abort,
 }: {
+  /**
+   * Username, or alias (e-mail, phone number)
+   */
   username: string;
   fragmentIdentifier: string;
   currentStatus?: BusyState | IdleState;

--- a/client/plaintext.ts
+++ b/client/plaintext.ts
@@ -26,6 +26,9 @@ export function authenticateWithPlaintextPassword({
   statusCb,
   clientMetadata,
 }: {
+  /**
+   * Username, or alias (e-mail, phone number)
+   */
   username: string;
   password: string;
   smsMfaCode?: () => Promise<string>;

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -449,7 +449,7 @@ function _usePasswordless() {
     requestSignInLink: (username: string) => {
       setLastError(undefined);
       const requesting = requestSignInLink({
-        usernameOrAlias: username,
+        username: username,
         statusCb: setSigninInStatus,
         currentStatus: signingInStatus,
       });

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -469,6 +469,9 @@ function _usePasswordless() {
       credentials,
       clientMetadata,
     }: {
+      /**
+       * Username, or alias (e-mail, phone number)
+       */
       username: string;
       credentials?: { id: string; transports?: AuthenticatorTransport[] }[];
       clientMetadata?: Record<string, string>;
@@ -491,6 +494,9 @@ function _usePasswordless() {
       smsMfaCode,
       clientMetadata,
     }: {
+      /**
+       * Username, or alias (e-mail, phone number)
+       */
       username: string;
       password: string;
       smsMfaCode?: () => Promise<string>;
@@ -515,6 +521,9 @@ function _usePasswordless() {
       smsMfaCode,
       clientMetadata,
     }: {
+      /**
+       * Username, or alias (e-mail, phone number)
+       */
       username: string;
       password: string;
       smsMfaCode?: () => Promise<string>;
@@ -538,6 +547,9 @@ function _usePasswordless() {
       smsMfaCode,
       clientMetadata,
     }: {
+      /**
+       * Username, or alias (e-mail, phone number)
+       */
       username: string;
       smsMfaCode: (phoneNumber: string, attempt: number) => Promise<string>;
       clientMetadata?: Record<string, string>;

--- a/client/react/react-native.ts
+++ b/client/react/react-native.ts
@@ -80,6 +80,9 @@ export async function fido2CreateCredential({
   username = "Anonymous",
   friendlyName,
 }: {
+  /**
+   * Username, or alias (e-mail, phone number)
+   */
   username: string;
   friendlyName: string;
 }) {
@@ -106,6 +109,9 @@ export async function fido2GetCredential({
   username = "Anonymous",
 }: {
   challenge: string;
+  /**
+   * Username, or alias (e-mail, phone number)
+   */
   username: string;
 }) {
   const config = configure();
@@ -121,7 +127,14 @@ export async function fido2GetCredential({
   };
 }
 
-export async function loginWithFido2({ username }: { username: string }) {
+export async function loginWithFido2({
+  username,
+}: {
+  /**
+   * Username, or alias (e-mail, phone number)
+   */
+  username: string;
+}) {
   const response = authenticateWithFido2({
     username,
     credentialGetter: ({ challenge }: { challenge: string }) => {

--- a/client/react/react-native.ts
+++ b/client/react/react-native.ts
@@ -77,7 +77,7 @@ export const toBase64String = (base64Url: string) =>
   base64Url.replace(/-/g, "+").replace(/_/g, "/") + "==";
 
 export async function fido2CreateCredential({
-  username = "Anonymous",
+  username,
   friendlyName,
 }: {
   /**
@@ -106,7 +106,7 @@ export async function fido2CreateCredential({
 
 export async function fido2GetCredential({
   challenge,
-  username = "Anonymous",
+  username,
 }: {
   challenge: string;
   /**

--- a/client/react/react-native.ts
+++ b/client/react/react-native.ts
@@ -81,7 +81,7 @@ export async function fido2CreateCredential({
   friendlyName,
 }: {
   /**
-   * Username, or alias (e-mail, phone number)
+   * Display name for the user
    */
   username: string;
   friendlyName: string;
@@ -110,7 +110,7 @@ export async function fido2GetCredential({
 }: {
   challenge: string;
   /**
-   * Username, or alias (e-mail, phone number)
+   * Display name for the user
    */
   username: string;
 }) {

--- a/client/sms-otp-stepup.ts
+++ b/client/sms-otp-stepup.ts
@@ -34,6 +34,9 @@ export function stepUpAuthenticationWithSmsOtp({
   currentStatus,
   clientMetadata,
 }: {
+  /**
+   * Username, or alias (e-mail, phone number)
+   */
   username: string;
   smsMfaCode: (phoneNumber: string, attempt: number) => Promise<string>;
   tokensCb?: (tokens: TokensFromSignIn) => void | Promise<void>;

--- a/client/srp.ts
+++ b/client/srp.ts
@@ -265,6 +265,9 @@ export function authenticateWithSRP({
   statusCb,
   clientMetadata,
 }: {
+  /**
+   * Username, or alias (e-mail, phone number)
+   */
   username: string;
   password: string;
   smsMfaCode?: () => Promise<string>;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Consistently use term username instead of usernameOrAlias. E.g. for FIDO2 sign in, SMS OTP Step up, username password sign-in: we use the parameter name `username`. Let's do the same for magic links instead of `usernameOrAlias` (there is no difference, depending on the settings of the User Pool you may use an alias instead of the real username)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
