### PR TITLE
Chore/tweaks

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -2,6 +2,34 @@
 
 > **_Oops:_** These docs are pretty incomplete and don't explain how to sign in yet :( For now, the best we have are some useful comments in this issue: https://github.com/aws-samples/amazon-cognito-passwordless-auth/issues/1
 
+### Configuration
+
+To use the library, you need to first configure it:
+
+```javascript
+import { Passwordless } from "amazon-cognito-passwordless-auth/react";
+
+Passwordless.configure({
+  cognitoIdpEndpoint: "eu-west-1", // you can also use the full endpoint URL, potentially to use a proxy
+  clientId: "<client id>",
+  // optional, only required if you want to use FIDO2:
+  fido2: {
+    baseUrl: "<fido2 base url>",
+    // optional, allows you to set WebAuthn options:
+    authenticatorSelection: {
+      userVerification: "required",
+    },
+  },
+  userPoolId: "<user pool id>", // optional, only required if you want to use USER_SRP_AUTH
+  // optional, additional headers that will be sent with each request to Cognito:
+  proxyApiHeaders: {
+    "<header 1>": "<value 1>",
+    "<header 2>": "<value 2>",
+  },
+  storage: window.localStorage, // Optional, default to localStorage
+});
+```
+
 ### Sign Up
 
 If your User Pool is enabled for self sign-up, users can sign up like so:

--- a/end-to-end-example/cdk/stack.ts
+++ b/end-to-end-example/cdk/stack.ts
@@ -44,10 +44,6 @@ class End2EndExampleStack extends cdk.Stack {
       },
       userPoolProps: {
         removalPolicy: cdk.RemovalPolicy.DESTROY,
-        signInAliases: {
-          email: true,
-        },
-        enableSmsRole: true,
       },
       fido2: {
         authenticatorsTableProps: {
@@ -64,10 +60,18 @@ class End2EndExampleStack extends cdk.Stack {
       },
       smsOtpStepUp: {},
       userPoolClientProps: {
+        // perrty short so you see token refreshes in action often:
         idTokenValidity: cdk.Duration.minutes(5),
         accessTokenValidity: cdk.Duration.minutes(5),
         refreshTokenValidity: cdk.Duration.hours(1),
+        // while testing/experimenting it's best to set this to false,
+        // so that when you try to sign in with a user that doesn't exist,
+        // Cognito will tell you that––and you don't wait for a magic link
+        // that will never arrive in your inbox:
+        preventUserExistenceErrors: false,
       },
+      // while testing/experimenting it's heplful to see e.g. full request details in logs:
+      logLevel: "DEBUG",
     });
 
     new cdk.CfnOutput(this, "UserPoolId", {
@@ -161,19 +165,6 @@ NagSuppressions.addResourceSuppressions(
     {
       id: "AwsSolutions-APIG1",
       reason: "Access logging is enabled using override, invisible to CDK Nag",
-    },
-  ],
-  true
-);
-NagSuppressions.addResourceSuppressionsByPath(
-  stack,
-  "/" + stackName + "/UserPoolPasswordless/smsRole/Resource",
-  [
-    {
-      id: "AwsSolutions-IAM5",
-      reason:
-        "SMS role is automatically created by CDK and requires sns:publish to any phone number",
-      appliesTo: ["Resource::*"],
     },
   ],
   true


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Added few more docs and tweaked to end-to-end test. Notably, set `preventUserExistenceErrors` to `false`, as I've seen various people forget to create the user in Cognito and then execute magic link sign-in and wait for a magic link that will never come (this is intended to prevent user enumeration, but during testing it is confusing&annoying)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
