### PR TITLE
Support using the client library in different runtimes than just Web, e.g. also in Node.js

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,8 +15,8 @@ module.exports = {
     getCdkOverrides("cdk/lib"),
     getCdkOverrides("cdk/custom-auth"),
     getCdkOverrides("end-to-end-example/cdk"),
-    getReactOverrides("client"),
-    getReactOverrides("end-to-end-example/client"),
+    getClientOverrides("client"),
+    getClientOverrides("end-to-end-example/client"),
   ],
   plugins: ["@typescript-eslint", "header", "import"],
   root: true,
@@ -56,7 +56,7 @@ function getCdkOverrides(basedir) {
   };
 }
 
-function getReactOverrides(basedir) {
+function getClientOverrides(basedir) {
   return {
     env: {
       browser: true,
@@ -86,6 +86,15 @@ function getReactOverrides(basedir) {
     rules: {
       ...rules(),
       "react/react-in-jsx-scope": "off",
+      "no-restricted-globals": [
+        "error",
+        "window",
+        "document",
+        "history",
+        "location",
+        "crypto",
+        "fetch",
+      ],
     },
     plugins: ["react", "@typescript-eslint", "header", "import"],
   };

--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ See [README-REACT.md](./client/react/README-REACT.md)
 
 See [README-REACT-NATIVE.md](./client/react/README-REACT-NATIVE.md)
 
+## Usage in JavaScript environments other than Web
+
+See [README.md](./client/README-NON-WEB.md)
+
 ## Customizing Auth
 
 If you want to do customization of this solution that goes beyond the parameters of the `Passwordless` construct, e.g. to use your own e-mail content for magic links, see [CUSTOMIZE-AUTH.md](./CUSTOMIZE-AUTH.md)

--- a/client/README-NON-WEB.md
+++ b/client/README-NON-WEB.md
@@ -22,7 +22,7 @@ You do not need to provide these implementations in all cases, so it's easiest w
 
 ## Examples
 
-This works in Node.js 18 and above:
+This works in Node.js 18 and above (but in Node.js 20 you don't need to do this as crypto has become a global, as in Web):
 
 ```typescript
 import { Passwordless } from "amazon-cognito-passwordless-auth";
@@ -64,6 +64,54 @@ Passwordless.configure({
   history: {
     pushState: () => {},
   },
+});
+
+const { signedIn } = signInWithLink();
+
+const tokens = await signedIn;
+
+console.log(tokens);
+```
+
+Same example but more fancy:
+
+```typescript
+import { Passwordless } from "amazon-cognito-passwordless-auth";
+import {
+  MinimalLocation,
+  MinimalHistory,
+} from "amazon-cognito-passwordless-auth/config";
+import { signInWithLink } from "amazon-cognito-passwordless-auth/magic-link";
+
+class CustomLocation implements MinimalLocation {
+  /**
+   * Implement a mechanism in Node.js to acquire and provide the magic link:
+   */
+  get href() {
+    return "https://abcdefghijk.cloudfront.net/#eyactualmagiclinkyrqfhahsv89grhz9rghrzhbvzxcvcbhzdrt4ut9qg...";
+  }
+  /**
+   * Implement a mechanism in Node.js to provide the hostname (used as default RP ID in FIDO2, unless configured itself):
+   */
+  get hostname() {
+    return "https://abcdefghijk.cloudfront.net";
+  }
+}
+
+class CustomHistory implements MinimalHistory {
+  /**
+   * Implement a mechanism in Node.js to navigate to the next page (might not be applicable in CLI scripts!)
+   */
+  pushState() {}
+}
+
+Passwordless.configure({
+  clientId: "<your client id>",
+  cognitoIdpEndpoint: "<your region>",
+  // override location
+  location: new CustomLocation(),
+  // override history
+  history: new CustomHistory(),
 });
 
 const { signedIn } = signInWithLink();

--- a/client/README-NON-WEB.md
+++ b/client/README-NON-WEB.md
@@ -94,7 +94,7 @@ class CustomLocation implements MinimalLocation {
    * Implement a mechanism in Node.js to provide the hostname (used as default RP ID in FIDO2, unless configured itself):
    */
   get hostname() {
-    return "https://abcdefghijk.cloudfront.net";
+    return "abcdefghijk.cloudfront.net";
   }
 }
 

--- a/client/README-NON-WEB.md
+++ b/client/README-NON-WEB.md
@@ -100,7 +100,7 @@ class CustomLocation implements MinimalLocation {
 
 class CustomHistory implements MinimalHistory {
   /**
-   * Implement a mechanism in Node.js to navigate to the next page (might not be applicable in CLI scripts!)
+   * Implement a mechanism in Node.js to change the current URL (probably not applicable in CLI scripts!)
    */
   pushState() {}
 }

--- a/client/README-NON-WEB.md
+++ b/client/README-NON-WEB.md
@@ -1,0 +1,74 @@
+# Usage in JavaScript runtimes other than Web (e.g. in Node.js)
+
+You can use this library also in JavaScript runtimes other than Web, for example in Node.js. In that case make sure you provide alternative implementations of some global variables that come out-of-the-box in web. Also, if you're running server-side you might want to use a client secret:
+
+```javascript
+import { Passwordless } from "amazon-cognito-passwordless-auth";
+
+Passwordless.configure({
+  ...otherConfig,
+  clientSecret: "secret", // User Pool Client secret
+  storage: YourStorageImplementation, // Custom storage implementation––if not provided and localStorage is undefined then MemoryStorage is used
+  fetch: YourFetchImplementation, // Custom fetch implementation
+  crypto: YourCryptoImplementation, // Custom crypto implementation
+  location: YourLocationImplementation, // Custom location implementation
+  history: YourHistoryImplementation, // Custom history implementation
+});
+```
+
+After that, you can use the library as you would in Web. See [./README.md](./README.md)
+
+You do not need to provide these implementations in all cases, so it's easiest while developing to try to use the library as you would and see if you run into a `UndefinedGlobalVariableError` and then implement that particular global. Also, you don't need to provide the full implementation of the global as exists in Web, just the pieces that this library needs: to figure out what those are it's best to check the typings in the [source code of the configure function](./config.ts).
+
+## Examples
+
+This works in Node.js 18 and above:
+
+```typescript
+import { Passwordless } from "amazon-cognito-passwordless-auth";
+import { authenticateWithSRP } from "amazon-cognito-passwordless-auth/srp";
+import { webcrypto } from "node:crypto";
+
+Passwordless.configure({
+  clientId: "<your client id>",
+  userPoolId: "<your pool>",
+  cognitoIdpEndpoint: "<your region>",
+  crypto: webcrypto, // override crypto
+});
+
+const { signedIn } = authenticateWithSRP({
+  username: "johndoe@example.com",
+  password: "OpenSesame",
+});
+
+const tokens = await signedIn;
+
+console.log(tokens);
+```
+
+And this:
+
+```typescript
+import { Passwordless } from "amazon-cognito-passwordless-auth";
+import { signInWithLink } from "amazon-cognito-passwordless-auth/magic-link";
+
+Passwordless.configure({
+  clientId: "<your client id>",
+  cognitoIdpEndpoint: "<your region>",
+  // override location, let's pretend the current href is the magic link:
+  location: {
+    href: "https://abcdefghijk.cloudfront.net/#eyactualmagiclinkyrqfhahsv89grhz9rghrzhbvzxcvcbhzdrt4ut9qg...",
+    hostname: "abcdefghijk.cloudfront.net",
+  },
+  // override history, mock implementation:
+  history: {
+    pushState: () => {},
+  },
+});
+
+const { signedIn } = signInWithLink();
+
+const tokens = await signedIn;
+
+console.log(tokens);
+```

--- a/client/README.md
+++ b/client/README.md
@@ -26,7 +26,7 @@ Passwordless.configure({
     "<header 1>": "<value 1>",
     "<header 2>": "<value 2>",
   },
-  storage: window.localStorage, // Optional, default to localStorage
+  storage: localStorage, // Optional, default to localStorage
 });
 ```
 

--- a/client/config.ts
+++ b/client/config.ts
@@ -26,6 +26,8 @@ export interface Config {
   cognitoIdpEndpoint: string;
   /** The Amazon Cognito Client ID */
   clientId: string;
+  /** The Amazon Cognito Client Secret (optional: don't use this in Web clients, use when running server side) */
+  clientSecret?: string;
   /** The Amazon Cognito User Pool ID */
   userPoolId?: string;
   /** FIDO2 (WebAuthn) configuration */

--- a/client/config.ts
+++ b/client/config.ts
@@ -86,21 +86,6 @@ export interface Config {
    */
   history?: MinimalHistory;
 }
-class MemoryStorage {
-  private memory: Map<string, string>;
-  constructor() {
-    this.memory = new Map();
-  }
-  getItem(key: string) {
-    return this.memory.get(key);
-  }
-  setItem(key: string, value: string) {
-    this.memory.set(key, value);
-  }
-  removeItem(key: string) {
-    this.memory.delete(key);
-  }
-}
 
 let config_:
   | (Config & {
@@ -192,6 +177,22 @@ interface AmplifyConfig {
 
 function isAmplifyConfig(c: unknown): c is AmplifyConfig {
   return !!c && typeof c === "object" && "Auth" in c;
+}
+
+class MemoryStorage {
+  private memory: Map<string, string>;
+  constructor() {
+    this.memory = new Map();
+  }
+  getItem(key: string) {
+    return this.memory.get(key);
+  }
+  setItem(key: string, value: string) {
+    this.memory.set(key, value);
+  }
+  removeItem(key: string) {
+    this.memory.delete(key);
+  }
 }
 
 export class UndefinedGlobalVariableError extends Error {}

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -142,7 +142,7 @@ export interface ParsedCredential {
 }
 
 export async function fido2StartCreateCredential() {
-  const { fido2 } = configure();
+  const { fido2, fetch, location } = configure();
   if (!fido2) {
     throw new Error("Missing Fido2 config");
   }
@@ -151,9 +151,7 @@ export async function fido2StartCreateCredential() {
     throw new Error("No JWT to invoke Fido2 API with");
   }
   const url = new URL(
-    `/register-authenticator/start?rpId=${
-      fido2.rp?.id ?? window.location.hostname
-    }`,
+    `/register-authenticator/start?rpId=${fido2.rp?.id ?? location.hostname}`,
     fido2.baseUrl
   );
   const method = "POST";
@@ -176,7 +174,7 @@ export async function fido2CompleteCreateCredential({
   credential: PublicKeyCredential | ParsedCredential;
   friendlyName: string;
 }) {
-  const { fido2 } = configure();
+  const { fido2, fetch } = configure();
   if (!fido2) {
     throw new Error("Missing Fido2 config");
   }
@@ -225,7 +223,7 @@ export async function fido2CompleteCreateCredential({
 }
 
 export async function fido2ListCredentials() {
-  const { fido2 } = configure();
+  const { fido2, fetch, location } = configure();
   if (!fido2) {
     throw new Error("Missing Fido2 config");
   }
@@ -234,7 +232,7 @@ export async function fido2ListCredentials() {
     throw new Error("No JWT to invoke Fido2 API with");
   }
   const url = new URL(
-    `/authenticators/list?rpId=${fido2.rp?.id ?? window.location.hostname}`,
+    `/authenticators/list?rpId=${fido2.rp?.id ?? location.hostname}`,
     fido2.baseUrl
   );
   return fetch(url, {
@@ -275,7 +273,7 @@ export async function fido2DeleteCredential({
 }: {
   credentialId: string;
 }) {
-  const { fido2 } = configure();
+  const { fido2, fetch } = configure();
   if (!fido2) {
     throw new Error("Missing Fido2 config");
   }
@@ -302,7 +300,7 @@ export async function fido2UpdateCredential({
   credentialId: string;
   friendlyName: string;
 }) {
-  const { fido2 } = configure();
+  const { fido2, fetch } = configure();
   if (!fido2) {
     throw new Error("Missing Fido2 config");
   }

--- a/client/magic-link.ts
+++ b/client/magic-link.ts
@@ -27,7 +27,7 @@ import {
   removeFragmentIdentifierFromBrowserLocation,
   bufferFromBase64Url,
 } from "./util.js";
-import { configure } from "./config.js";
+import { configure, UndefinedGlobalVariableError } from "./config.js";
 import { CognitoIdTokenPayload } from "./jwt-model.js";
 
 export const requestSignInLink = ({
@@ -101,11 +101,11 @@ export const requestSignInLink = ({
 
 const failedFragmentIdentifieres = new Set<string>();
 function checkCurrentLocationForSignInLink() {
-  const { debug } = configure();
+  const { debug, location } = configure();
   let url: URL;
   let fragmentIdentifier: string;
   try {
-    url = new URL(window.location?.href);
+    url = new URL(location.href);
     fragmentIdentifier = url.hash?.slice(1);
     if (!fragmentIdentifier) {
       debug?.(
@@ -120,7 +120,9 @@ function checkCurrentLocationForSignInLink() {
       return;
     }
   } catch (e) {
-    // TODO Implement DeepLinks for React Native MagicLink Support
+    if (e instanceof UndefinedGlobalVariableError) {
+      throw e;
+    }
     debug?.("Couldn't parse location url");
     return;
   }

--- a/client/react/README-REACT.md
+++ b/client/react/README-REACT.md
@@ -173,7 +173,7 @@ Passwordless.configure({
     "<header 1>": "<value 1>",
     "<header 2>": "<value 2>",
   },
-  storage: window.localStorage, // Optional, default to localStorage
+  storage: localStorage, // Optional, default to localStorage
 });
 ```
 

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -243,9 +243,9 @@ function _usePasswordless() {
 
   // Give easy access to isUserVerifyingPlatformAuthenticatorAvailable
   useEffect(() => {
-    if (window.PublicKeyCredential) {
+    if (typeof PublicKeyCredential !== "undefined") {
       const cancel = new AbortController();
-      window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
+      PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
         .then((res) => {
           if (!cancel.signal.aborted) {
             setUserVerifyingPlatformAuthenticatorAvailable(res);

--- a/client/util.ts
+++ b/client/util.ts
@@ -16,8 +16,9 @@ import {
   CognitoAccessTokenPayload,
   CognitoIdTokenPayload,
 } from "./jwt-model.js";
+import { MinimalResponse, configure } from "./config.js";
 
-export async function throwIfNot2xx(res: Response) {
+export async function throwIfNot2xx(res: MinimalResponse) {
   if (res.ok) {
     return res;
   }
@@ -61,21 +62,24 @@ export function setTimeoutWallClock<T>(cb: () => T, ms: number) {
       cb();
     }
   }, 1000);
+
+  // unref the interval if we can, so that e.g. when running in Node.js
+  // this interval would not block program exit:
+  if (typeof i.unref === "function") i.unref();
+
   return () => clearInterval(i);
 }
 
 export function currentBrowserLocationWithoutFragmentIdentifier() {
-  const current = new URL(window.location.href);
+  const { location } = configure();
+  const current = new URL(location.href);
   current.hash = "";
   return current.href;
 }
 
 export function removeFragmentIdentifierFromBrowserLocation() {
-  window.history.pushState(
-    "",
-    document.title,
-    currentBrowserLocationWithoutFragmentIdentifier()
-  );
+  const { history } = configure();
+  history.pushState("", "", currentBrowserLocationWithoutFragmentIdentifier());
 }
 
 export function timeAgo(now: Date, historicDate?: Date) {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Instead of assuming the existence of globals (such as the `window` object, `crypto`, `location` etc.) first try using values configured with `Passwordless.configure()`. Thus, in runtimes other than Web,  you can then also use the client library, as long as you configure the right replacement.

This basically expands on what we were already doing with config option `storage`, where you could add your own storage option instead of us assuming `localStorage` to be available.

## Examples

This works in Node.js 18 and above:

```typescript
import { Passwordless } from "amazon-cognito-passwordless-auth";
import { authenticateWithSRP } from "amazon-cognito-passwordless-auth/srp";
import { webcrypto } from "node:crypto";

Passwordless.configure({
  clientId: "<your client id>",
  userPoolId: "<your pool>",
  cognitoIdpEndpoint: "<your region>",
  crypto: webcrypto, // override crypto
});

const { signedIn } = authenticateWithSRP({
  username: "johndoe@example.com",
  password: "OpenSesame",
});

const tokens = await signedIn;

console.log(tokens);
```

And this:

```typescript
import { Passwordless } from "amazon-cognito-passwordless-auth";
import { signInWithLink } from "amazon-cognito-passwordless-auth/magic-link";

Passwordless.configure({
  clientId: "<your client id>",
  cognitoIdpEndpoint: "<your region>",
  // override location, let's pretend the current href is the magic link:
  location: {
    href: "https://abcdefghijk.cloudfront.net/#eyactualmagiclinkyrqfhahsv89grhz9rghrzhbvzxcvcbhzdrt4ut9qg...",
    hostname: "abcdefghijk.cloudfront.net",
  },
  // override history, mock implementation:
  history: {
    pushState: () => {},
  },
});

const { signedIn } = signInWithLink();

const tokens = await signedIn;

console.log(tokens);
```

Same example but more fancy:

```typescript
import { Passwordless } from "amazon-cognito-passwordless-auth";
import {
  MinimalLocation,
  MinimalHistory,
} from "amazon-cognito-passwordless-auth/config";
import { signInWithLink } from "amazon-cognito-passwordless-auth/magic-link";

class CustomLocation implements MinimalLocation {
  /**
   * Implement a mechanism in Node.js to acquire and provide the magic link:
   */
  get href() {
    return "https://abcdefghijk.cloudfront.net/#eyactualmagiclinkyrqfhahsv89grhz9rghrzhbvzxcvcbhzdrt4ut9qg...";
  }
  /**
   * Implement a mechanism in Node.js to provide the hostname (used as default RP ID in FIDO2, unless configured itself):
   */
  get hostname() {
    return "abcdefghijk.cloudfront.net";
  }
}

class CustomHistory implements MinimalHistory {
  /**
   * Implement a mechanism in Node.js to change the current URL (probably not applicable in CLI scripts!)
   */
  pushState() {}
}

Passwordless.configure({
  clientId: "<your client id>",
  cognitoIdpEndpoint: "<your region>",
  // override location
  location: new CustomLocation(),
  // override history
  history: new CustomHistory(),
});

const { signedIn } = signInWithLink();

const tokens = await signedIn;

console.log(tokens);
```

Note: In these examples I didn't override `fetch` as Node.js supports that as a global now too, but you could and it would work similar.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
