### PR TITLE
fix(react-native): build minimal location from passkeyDomain

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -7,7 +7,7 @@
 To use the library, you need to first configure it:
 
 ```javascript
-import { Passwordless } from "amazon-cognito-passwordless-auth";
+import { Passwordless } from "amazon-cognito-passwordless-auth/react";
 
 Passwordless.configure({
   cognitoIdpEndpoint: "eu-west-1", // you can also use the full endpoint URL, potentially to use a proxy
@@ -15,10 +15,26 @@ Passwordless.configure({
   // optional, only required if you want to use FIDO2:
   fido2: {
     baseUrl: "<fido2 base url>",
-    // optional, allows you to set WebAuthn options:
+    /**
+     * all other FIDO2 config is optional, values below are examples only to illustrate what you might configure:
+     */
     authenticatorSelection: {
-      userVerification: "required",
+      userVerification: "required", // even though optional, this one you probably want to explicitly specify as "required"
+      requireResidentKey: true,
+      residentKey: "preferred",
+      authenticatorAttachment: "platform",
     },
+    rp: {
+      id: "example.com",
+      name: "Example",
+    },
+    attestation: "direct",
+    extensions: {
+      appid: "u2f.example.com",
+      credProps: true,
+      hmacCreateSecret: true,
+    },
+    timeout: 120000,
   },
   userPoolId: "<user pool id>", // optional, only required if you want to use USER_SRP_AUTH
   // optional, additional headers that will be sent with each request to Cognito:

--- a/client/config.ts
+++ b/client/config.ts
@@ -87,15 +87,12 @@ export interface Config {
   history?: MinimalHistory;
 }
 
-let config_:
-  | (Config & {
-      storage: NonNullable<Config["storage"]>;
-      crypto: NonNullable<Config["crypto"]>;
-      fetch: NonNullable<Config["fetch"]>;
-      location: NonNullable<Config["location"]>;
-      history: NonNullable<Config["history"]>;
-    })
-  | undefined = undefined;
+export type ConfigWithDefaults = Config &
+  Required<
+    Pick<Config, "storage" | "crypto" | "fetch" | "location" | "history">
+  >;
+
+let config_: ConfigWithDefaults | undefined = undefined;
 export function configure(config?: Config) {
   if (config) {
     config_ = {

--- a/client/react/README-REACT-NATIVE.md
+++ b/client/react/README-REACT-NATIVE.md
@@ -115,29 +115,12 @@ function App() {
        */
       passkeyDomain: "<ASSOCIATED_PASSKEY_DOMAIN>",
       /**
-       * React Native App Name. Used by iOS and Android to show your app's name within the passkey dialog
+       * Configure Relying Party ID
        */
-      passkeyAppName: "<YOUR_APP_NAME>",
-      /**
-       * all other FIDO2 config is optional, values below are examples only to illustrate what you might configure:
-       */
-      authenticatorSelection: {
-        userVerification: "required", // even though optional, this one you probably want to explicitly specify as "required"
-        requireResidentKey: true,
-        residentKey: "preferred",
-        authenticatorAttachment: "platform",
-      },
       rp: {
         id: "example.com", // default: your passkeyDomain
-        name: "Example",
+        name: "Example.com", // default: your passkeyDomain
       },
-      attestation: "direct",
-      extensions: {
-        appid: "u2f.example.com",
-        credProps: true,
-        hmacCreateSecret: true,
-      },
-      timeout: 120000,
     },
     userPoolId: "<user pool id>", // optional, only required if you want to use USER_SRP_AUTH
     // optional, additional headers that will be sent with each request to Cognito:

--- a/client/react/README-REACT-NATIVE.md
+++ b/client/react/README-REACT-NATIVE.md
@@ -104,10 +104,40 @@ function App() {
     // optional, only required if you want to use FIDO2:
     fido2: {
       baseUrl: "<fido2 base url>",
-      // optional, allows you to set WebAuthn options:
+      /**
+       * React Native Passkey Domain. Used by iOS and Android to link your app's passkeys to your domain
+       * That domain must serve the mandatory manifest json required by Apple and Google under the following paths:
+       * - iOS: https://<your_passkey_domain>/.well-known/apple-app-site-association
+       * - Android: https://<your_passkey_domain>/.well-known/assetlinks.json
+       * More info:
+       * - iOS: https://developer.apple.com/documentation/xcode/supporting-associated-domains
+       * - Android: https://developer.android.com/training/sign-in/passkeys#add-support-dal
+       */
+      passkeyDomain: "<ASSOCIATED_PASSKEY_DOMAIN>",
+      /**
+       * React Native App Name. Used by iOS and Android to show your app's name within the passkey dialog
+       */
+      passkeyAppName: "<YOUR_APP_NAME>",
+      /**
+       * all other FIDO2 config is optional, values below are examples only to illustrate what you might configure:
+       */
       authenticatorSelection: {
-        userVerification: "required",
+        userVerification: "required", // even though optional, this one you probably want to explicitly specify as "required"
+        requireResidentKey: true,
+        residentKey: "preferred",
+        authenticatorAttachment: "platform",
       },
+      rp: {
+        id: "example.com", // default: your passkeyDomain
+        name: "Example",
+      },
+      attestation: "direct",
+      extensions: {
+        appid: "u2f.example.com",
+        credProps: true,
+        hmacCreateSecret: true,
+      },
+      timeout: 120000,
     },
     userPoolId: "<user pool id>", // optional, only required if you want to use USER_SRP_AUTH
     // optional, additional headers that will be sent with each request to Cognito:
@@ -116,11 +146,6 @@ function App() {
       "<header 2>": "<value 2>",
     },
     storage: AsyncStorage, // Need to set this for React Native, as the default (localStorage) will not work
-    // Need to set these for React Native:
-    native: {
-      passkeyDomain: "<ASSOCIATED_PASSKEY_DOMAIN>",
-      passkeyAppName: "<YOUR_APPS_NAME>",
-    },
   });
   // Your original App here
 }

--- a/client/react/README-REACT.md
+++ b/client/react/README-REACT.md
@@ -162,10 +162,26 @@ Passwordless.configure({
   // optional, only required if you want to use FIDO2:
   fido2: {
     baseUrl: "<fido2 base url>",
-    // optional, allows you to set WebAuthn options:
+    /**
+     * all other FIDO2 config is optional, values below are examples only to illustrate what you might configure:
+     */
     authenticatorSelection: {
-      userVerification: "required",
+      userVerification: "required", // even though optional, this one you probably want to explicitly specify as "required"
+      requireResidentKey: true,
+      residentKey: "preferred",
+      authenticatorAttachment: "platform",
     },
+    rp: {
+      id: "example.com",
+      name: "Example",
+    },
+    attestation: "direct",
+    extensions: {
+      appid: "u2f.example.com",
+      credProps: true,
+      hmacCreateSecret: true,
+    },
+    timeout: 120000,
   },
   userPoolId: "<user pool id>", // optional, only required if you want to use USER_SRP_AUTH
   // optional, additional headers that will be sent with each request to Cognito:

--- a/client/react/react-native.ts
+++ b/client/react/react-native.ts
@@ -110,7 +110,7 @@ export async function fido2CreateCredential({
   const passkey = new Passkey(config.fido2?.passkeyDomain, username);
   const credential = await passkey.register(
     toBase64String(response.challenge),
-    response.user.id,
+    response.user.id
   );
 
   return await fido2CompleteCreateCredential({
@@ -249,14 +249,14 @@ class RNTextDecoder {
         codePoints.push(
           ((byte & 0x0f) << 12) |
             ((readContinuationByte() & 0x3f) << 6) |
-            (readContinuationByte() & 0x3f),
+            (readContinuationByte() & 0x3f)
         );
       } else if (byte >> 3 === 0b11110) {
         codePoints.push(
           ((byte & 0x07) << 18) |
             ((readContinuationByte() & 0x3f) << 12) |
             ((readContinuationByte() & 0x3f) << 6) |
-            (readContinuationByte() & 0x3f),
+            (readContinuationByte() & 0x3f)
         );
       } else {
         RNTextDecoder.throwMalformedInputError();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
React Native does not have `window.location` nor `location` object. However, since we must pass the passkeyDomain we can use that to "simulate" a MinimalLocation object so the user does not need to input extra "location" config.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
