### PR TITLE
Fix number type

### DIFF
--- a/cdk/lib/cognito-passwordless.ts
+++ b/cdk/lib/cognito-passwordless.ts
@@ -87,13 +87,13 @@ export class Passwordless extends Construct {
            *
            * @default 1000
            */
-          throttlingBurstLimit?: 1000;
+          throttlingBurstLimit?: number;
           /**
            * The throttling rate limit for the deployment stage: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-request-throttling.html
            *
            * @default 2000
            */
-          throttlingRateLimit?: 2000;
+          throttlingRateLimit?: number;
           /**
            * Create a log role for API Gateway and add this to API Gateway account settings?
            * Set to false if you have already set this up in your account and region,


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* The types for throttling parameters were erroneously set to their default values instead of the generic `number` type. This has now been fixed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
