### PR TITLE
Update fido challenge lambda to use fido2Challenge function props

### DIFF
--- a/cdk/lib/cognito-passwordless.ts
+++ b/cdk/lib/cognito-passwordless.ts
@@ -651,7 +651,7 @@ export class Passwordless extends Construct {
             format: cdk.aws_lambda_nodejs.OutputFormat.ESM,
           },
           timeout: cdk.Duration.seconds(30),
-          ...props.functionProps?.fido2,
+          ...props.functionProps?.fido2challenge,
           environment: {
             LOG_LEVEL: props.logLevel ?? "INFO",
             DYNAMODB_AUTHENTICATORS_TABLE: this.authenticatorsTable!.tableName,


### PR DESCRIPTION
Issue #, if available: #104

Description of changes: Updates the constructor for the Fido2Challenge lambda function to use the props provided to fido2challenge instead of the base fido2 function props.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
