### PR TITLE
Fix userHandle determination

### DIFF
--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -547,6 +547,15 @@ export function authenticateWithFido2({
         username = new TextDecoder().decode(
           bufferFromBase64Url(fido2credential.userHandleB64)
         );
+        // The userHandle must map to a username, not a sub
+        if (username.startsWith("s|")) {
+          debug?.(
+            "Credential userHandle isn't a username. In order to use the username as userHandle, so users can sign in without typing their username, usernames must be opaque"
+          );
+          throw new Error("Username is required for initiating sign-in");
+        }
+        // remove (potential) prefix to recover username
+        username = username.replace(/^u\|/, "");
         debug?.(
           `Proceeding with discovered credential for username: ${username} (b64: ${fido2credential.userHandleB64})`
         );


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Tweak logic that determines userHandle so that (1) collisions between users are prevented and (2) the client (UI) can show a meaningful error message in cases where usernameless sign-in (using discoverable credential) is not possible.

About (1): such collisions were possible if one user would sign up with a `username` that's the same as the `sub` of another user. Note: this was only possible for users pool that were configured to support self sign up, and allow signing in with a username (v.s. only email and/or phone number). In these cases, collision are an unlikely but possible scenario (user A would have to know the `sub` of user B, as guessing a `sub` is practically impossible).

THIS IS A BREAKING CHANGE: if your user pool was configured with `username` as sign-in option (v.s. only email and/or phone number) all existing FIDO2 credentials become unusable and must be re-created. We're **_VERY_** sorry about that and are convinced this is a necessary change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
