### PR TITLE
Update to set CfnWebACLAssociation only if addWaf is true

### DIFF
--- a/cdk/lib/cognito-passwordless.ts
+++ b/cdk/lib/cognito-passwordless.ts
@@ -1022,11 +1022,11 @@ export class Passwordless extends Construct {
             ],
           }
         );
+        new cdk.aws_wafv2.CfnWebACLAssociation(scope, `WafAssociation${id}`, {
+          resourceArn: this.fido2Api.deploymentStage.stageArn,
+          webAclArn: this.fido2ApiWebACL.attrArn,
+        });
       }
-      new cdk.aws_wafv2.CfnWebACLAssociation(scope, `WafAssociation${id}`, {
-        resourceArn: this.fido2Api.deploymentStage.stageArn,
-        webAclArn: this.fido2ApiWebACL!.attrArn,
-      });
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:* #107

*Description of changes:*
Moves the CfnWebACLAssociation to inside the `if (props.fido2.api?.addWaf !== false)` statement. This should prevent the error `TypeError: Cannot read properties of undefined (reading 'attrArn')` when addWaf is false


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
