### PR TITLE
Add fido rest api props

### DIFF
--- a/cdk/lib/cognito-passwordless.ts
+++ b/cdk/lib/cognito-passwordless.ts
@@ -116,6 +116,10 @@ export class Passwordless extends Construct {
            * @default 100
            */
           wafRateLimitPerIp?: number;
+          /**
+           * Pass any properties you want for the AWS Lambda Rest Api created, these will be merged with properties from this solution
+           */
+          lambdaRestApiProps?: Partial<cdk.aws_apigateway.LambdaRestApiProps>;
         };
       };
       /**
@@ -703,6 +707,7 @@ export class Passwordless extends Construct {
         this,
         `RestApi${id}`,
         {
+          ...props.fido2.api?.lambdaRestApiProps,
           proxy: false,
           handler: this.fido2Fn,
           deployOptions: {
@@ -766,6 +771,7 @@ export class Passwordless extends Construct {
                   cdk.aws_apigateway.AccessLogField.contextDomainName(),
               })
             ),
+            ...props.fido2.api?.lambdaRestApiProps?.deployOptions,
           },
         }
       );

--- a/cdk/lib/cognito-passwordless.ts
+++ b/cdk/lib/cognito-passwordless.ts
@@ -119,7 +119,7 @@ export class Passwordless extends Construct {
           /**
            * Pass any properties you want for the AWS Lambda Rest Api created, these will be merged with properties from this solution
            */
-          lambdaRestApiProps?: Partial<cdk.aws_apigateway.LambdaRestApiProps>;
+          restApiProps?: Partial<cdk.aws_apigateway.RestApiProps>;
         };
       };
       /**
@@ -707,9 +707,9 @@ export class Passwordless extends Construct {
         this,
         `RestApi${id}`,
         {
-          ...props.fido2.api?.lambdaRestApiProps,
           proxy: false,
           handler: this.fido2Fn,
+          ...props.fido2.api?.restApiProps,
           deployOptions: {
             loggingLevel: cdk.aws_apigateway.MethodLoggingLevel.ERROR,
             metricsEnabled: true,
@@ -771,7 +771,7 @@ export class Passwordless extends Construct {
                   cdk.aws_apigateway.AccessLogField.contextDomainName(),
               })
             ),
-            ...props.fido2.api?.lambdaRestApiProps?.deployOptions,
+            ...props.fido2.api?.restApiProps?.deployOptions,
           },
         }
       );


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This changes add props to be passed to the `LambdaRestApi` construct. I've decided to use the `RestApiProps` rather than `LambdaRestApiProps` to prevent the user from overriding the proxy and handler values which could cause problems.

I'm not sure if `restApiProps` is a good enough name for the field so feel free to update if there's any better ideas.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
