### PR TITLE
Add AllowedApplicationOrigin environment variable for non url origins

### DIFF
--- a/cdk/custom-auth/common.ts
+++ b/cdk/custom-auth/common.ts
@@ -150,9 +150,13 @@ export function withCommonHeaders<T extends APIGatewayProxyHandler>(
   return wrapped as T;
 }
 
-export function checkClientOrigin(origin: string, allowedOrigins: string[], allowedApplicationOrigins: string[]): boolean {
+export function checkClientOrigin(
+  origin: string,
+  allowedOrigins: string[],
+  allowedApplicationOrigins: string[]
+): boolean {
   if (allowedApplicationOrigins.includes(origin)) {
-    return true
+    return true;
   }
 
   return allowedOrigins.includes(new URL(origin).origin);

--- a/cdk/custom-auth/common.ts
+++ b/cdk/custom-auth/common.ts
@@ -151,7 +151,7 @@ export function withCommonHeaders<T extends APIGatewayProxyHandler>(
 }
 
 export function checkClientOrigin(origin: string, allowedOrigins: string[], allowedApplicationOrigins: string[]): boolean {
-  if (allowedApplicationOrigins.length > 0 && allowedApplicationOrigins.includes(origin)) {
+  if (allowedApplicationOrigins.includes(origin)) {
     return true
   }
 

--- a/cdk/custom-auth/common.ts
+++ b/cdk/custom-auth/common.ts
@@ -149,3 +149,16 @@ export function withCommonHeaders<T extends APIGatewayProxyHandler>(
   };
   return wrapped as T;
 }
+
+export function checkClientOrigin(origin: string): boolean {
+  const allowedApplicationOrigins = process.env.ALLOWED_APPLICATION_ORIGINS?.split(",") ?? [];
+  const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(",")
+      .map((href) => new URL(href))
+      .map((url) => url.origin) ?? [];
+
+  if (allowedApplicationOrigins.length > 0 && allowedApplicationOrigins.includes(origin)) {
+    return true
+  }
+
+  return allowedOrigins.length > 0 && allowedOrigins.includes(new URL(origin).origin);
+}

--- a/cdk/custom-auth/common.ts
+++ b/cdk/custom-auth/common.ts
@@ -150,14 +150,14 @@ export function withCommonHeaders<T extends APIGatewayProxyHandler>(
   return wrapped as T;
 }
 
-export function checkClientOrigin(
+export function isValidOrigin(
   origin: string,
-  allowedOrigins: string[],
+  allowedWebOrigins: string[],
   allowedApplicationOrigins: string[]
 ): boolean {
-  if (allowedApplicationOrigins.includes(origin)) {
-    return true;
-  }
-
-  return allowedOrigins.includes(new URL(origin).origin);
+  return (
+    !!origin &&
+    (allowedApplicationOrigins.includes(origin) ||
+      allowedWebOrigins.includes(origin))
+  );
 }

--- a/cdk/custom-auth/common.ts
+++ b/cdk/custom-auth/common.ts
@@ -150,15 +150,10 @@ export function withCommonHeaders<T extends APIGatewayProxyHandler>(
   return wrapped as T;
 }
 
-export function checkClientOrigin(origin: string): boolean {
-  const allowedApplicationOrigins = process.env.ALLOWED_APPLICATION_ORIGINS?.split(",") ?? [];
-  const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(",")
-      .map((href) => new URL(href))
-      .map((url) => url.origin) ?? [];
-
+export function checkClientOrigin(origin: string, allowedOrigins: string[], allowedApplicationOrigins: string[]): boolean {
   if (allowedApplicationOrigins.length > 0 && allowedApplicationOrigins.includes(origin)) {
     return true
   }
 
-  return allowedOrigins.length > 0 && allowedOrigins.includes(new URL(origin).origin);
+  return allowedOrigins.includes(new URL(origin).origin);
 }

--- a/cdk/custom-auth/fido2-credentials-api.ts
+++ b/cdk/custom-auth/fido2-credentials-api.ts
@@ -51,7 +51,8 @@ const allowedRelyingPartyIdHashes = allowedRelyingPartyIds.map(
     createHash("sha256").update(relyingPartyId).digest("base64url")
 );
 const relyingPartyName = process.env.RELYING_PARTY_NAME!;
-const allowedApplicationOrigins = process.env.ALLOWED_APPLICATION_ORIGINS?.split(",") ?? [];
+const allowedApplicationOrigins =
+  process.env.ALLOWED_APPLICATION_ORIGINS?.split(",") ?? [];
 const allowedOrigins =
   process.env.ALLOWED_ORIGINS?.split(",")
     .map((href) => new URL(href))
@@ -559,7 +560,13 @@ async function handleCredentialsResponse(
     throw new UserFacingError("Challenge not found");
   }
   logger.debug("Challenge found:", JSON.stringify(storedChallenge));
-  if (!checkClientOrigin(clientData.origin, allowedOrigins, allowedApplicationOrigins)) {
+  if (
+    !checkClientOrigin(
+      clientData.origin,
+      allowedOrigins,
+      allowedApplicationOrigins
+    )
+  ) {
     throw new UserFacingError(
       `Invalid clientData origin: ${clientData.origin}`
     );

--- a/cdk/custom-auth/fido2-credentials-api.ts
+++ b/cdk/custom-auth/fido2-credentials-api.ts
@@ -56,8 +56,8 @@ const allowedOrigins =
   process.env.ALLOWED_ORIGINS?.split(",")
     .map((href) => new URL(href))
     .map((url) => url.origin) ?? [];
-if (!allowedApplicationOrigins.length && !allowedOrigins.length)
-  throw new Error("Environment variable ALLOWED_ORIGINS or ALLOWED_APPLICATION_ORIGINS is not set");
+if (!allowedOrigins.length)
+  throw new Error("Environment variable ALLOWED_ORIGINS is not set");
 const authenticatorRegistrationTimeout = Number(
   process.env.AUTHENTICATOR_REGISTRATION_TIMEOUT ?? "300000"
 );
@@ -559,7 +559,7 @@ async function handleCredentialsResponse(
     throw new UserFacingError("Challenge not found");
   }
   logger.debug("Challenge found:", JSON.stringify(storedChallenge));
-  if (!checkClientOrigin(clientData.origin)) {
+  if (!checkClientOrigin(clientData.origin, allowedOrigins, allowedApplicationOrigins)) {
     throw new UserFacingError(
       `Invalid clientData origin: ${clientData.origin}`
     );

--- a/cdk/custom-auth/fido2-credentials-api.ts
+++ b/cdk/custom-auth/fido2-credentials-api.ts
@@ -33,7 +33,7 @@ import {
   handleConditionalCheckFailedException,
   UserFacingError,
   withCommonHeaders,
-  checkClientOrigin,
+  isValidOrigin,
 } from "./common.js";
 import { NotificationPayload } from "./fido2-notification.js";
 
@@ -561,11 +561,7 @@ async function handleCredentialsResponse(
   }
   logger.debug("Challenge found:", JSON.stringify(storedChallenge));
   if (
-    !checkClientOrigin(
-      clientData.origin,
-      allowedOrigins,
-      allowedApplicationOrigins
-    )
+    !isValidOrigin(clientData.origin, allowedOrigins, allowedApplicationOrigins)
   ) {
     throw new UserFacingError(
       `Invalid clientData origin: ${clientData.origin}`

--- a/cdk/custom-auth/fido2.ts
+++ b/cdk/custom-auth/fido2.ts
@@ -26,7 +26,12 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 import { JsonWebKey } from "crypto";
 import { createVerify, createHash, createPublicKey, randomBytes } from "crypto";
-import {logger, UserFacingError, determineUserHandle, checkClientOrigin} from "./common.js";
+import {
+  logger,
+  UserFacingError,
+  determineUserHandle,
+  checkClientOrigin,
+} from "./common.js";
 
 const ddbDocClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 interface StoredCredential {
@@ -46,7 +51,8 @@ let config = {
   allowedOrigins: process.env.ALLOWED_ORIGINS?.split(",")
     .map((href) => new URL(href))
     .map((url) => url.origin),
-  allowedApplicationOrigins: process.env.ALLOWED_APPLICATION_ORIGINS?.split(","),
+  allowedApplicationOrigins:
+    process.env.ALLOWED_APPLICATION_ORIGINS?.split(","),
   /** The set of Relying Party IDs thay may initiate FIDO2 sign-in */
   allowedRelyingPartyIds: process.env.ALLOWED_RELYING_PARTY_IDS?.split(","),
   /** The Relying Party ID to use (optional, if not set user agents will use the current domain) */
@@ -271,7 +277,13 @@ export async function verifyChallenge({
   }
 
   // Verify origin
-  if (!checkClientOrigin(clientData.origin, requireConfig("allowedOrigins"), config.allowedApplicationOrigins ?? [])) {
+  if (
+    !checkClientOrigin(
+      clientData.origin,
+      requireConfig("allowedOrigins"),
+      config.allowedApplicationOrigins ?? []
+    )
+  ) {
     throw new Error(`Invalid clientData origin: ${clientData.origin}`);
   }
 

--- a/cdk/custom-auth/fido2.ts
+++ b/cdk/custom-auth/fido2.ts
@@ -46,7 +46,7 @@ let config = {
   allowedOrigins: process.env.ALLOWED_ORIGINS?.split(",")
     .map((href) => new URL(href))
     .map((url) => url.origin),
-  allowedApplicationOrigins: process.env.ALLOWED_APPLICATION_ORIGINS?.split(",") ?? [],
+  allowedApplicationOrigins: process.env.ALLOWED_APPLICATION_ORIGINS?.split(","),
   /** The set of Relying Party IDs thay may initiate FIDO2 sign-in */
   allowedRelyingPartyIds: process.env.ALLOWED_RELYING_PARTY_IDS?.split(","),
   /** The Relying Party ID to use (optional, if not set user agents will use the current domain) */
@@ -271,7 +271,7 @@ export async function verifyChallenge({
   }
 
   // Verify origin
-  if (!checkClientOrigin(clientData.origin)) {
+  if (!checkClientOrigin(clientData.origin, requireConfig("allowedOrigins"), config.allowedApplicationOrigins ?? [])) {
     throw new Error(`Invalid clientData origin: ${clientData.origin}`);
   }
 

--- a/cdk/custom-auth/fido2.ts
+++ b/cdk/custom-auth/fido2.ts
@@ -30,7 +30,7 @@ import {
   logger,
   UserFacingError,
   determineUserHandle,
-  checkClientOrigin,
+  isValidOrigin,
 } from "./common.js";
 
 const ddbDocClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -278,7 +278,7 @@ export async function verifyChallenge({
 
   // Verify origin
   if (
-    !checkClientOrigin(
+    !isValidOrigin(
       clientData.origin,
       requireConfig("allowedOrigins"),
       config.allowedApplicationOrigins ?? []

--- a/cdk/lib/cognito-passwordless.ts
+++ b/cdk/lib/cognito-passwordless.ts
@@ -58,6 +58,10 @@ export class Passwordless extends Construct {
        */
       allowedOrigins?: string[];
       /**
+       * Probably write something
+       */
+      allowedApplicationOrigins?: string[]
+      /**
        * Enable sign-in with FIDO2 by providing this config object.
        */
       fido2?: {
@@ -274,6 +278,7 @@ export class Passwordless extends Construct {
 
     const createAuthChallengeEnvironment: Record<string, string> = {
       ALLOWED_ORIGINS: props.allowedOrigins?.join(",") ?? "",
+      ALLOWED_APPLICATION_ORIGINS: props.allowedApplicationOrigins?.join(",") ?? "",
       LOG_LEVEL: props.logLevel ?? "INFO",
     };
     if (props.magicLink) {
@@ -401,6 +406,7 @@ export class Passwordless extends Construct {
     });
     const verifyAuthChallengeResponseEnvironment: Record<string, string> = {
       ALLOWED_ORIGINS: props.allowedOrigins?.join(",") ?? "",
+      ALLOWED_APPLICATION_ORIGINS: props.allowedApplicationOrigins?.join(",") ?? "",
       LOG_LEVEL: props.logLevel ?? "INFO",
     };
     if (props.magicLink) {
@@ -679,6 +685,7 @@ export class Passwordless extends Construct {
             ALLOWED_RELYING_PARTY_IDS:
               props.fido2.allowedRelyingPartyIds.join(",") ?? "",
             ALLOWED_ORIGINS: props.allowedOrigins?.join(",") ?? "",
+            ALLOWED_APPLICATION_ORIGINS: props.allowedApplicationOrigins?.join(",") ?? "",
             ATTESTATION: props.fido2.attestation ?? "none",
             USER_VERIFICATION: props.fido2.userVerification ?? "required",
             AUTHENTICATOR_ATTACHMENT: props.fido2.authenticatorAttachment ?? "",

--- a/cdk/lib/cognito-passwordless.ts
+++ b/cdk/lib/cognito-passwordless.ts
@@ -60,7 +60,7 @@ export class Passwordless extends Construct {
       /**
        * The non web-app origins that will be allowed to authenticate via FIDO2. These may include origins which are not URLs.
        */
-      allowedApplicationOrigins?: string[]
+      allowedApplicationOrigins?: string[];
       /**
        * Enable sign-in with FIDO2 by providing this config object.
        */
@@ -278,7 +278,8 @@ export class Passwordless extends Construct {
 
     const createAuthChallengeEnvironment: Record<string, string> = {
       ALLOWED_ORIGINS: props.allowedOrigins?.join(",") ?? "",
-      ALLOWED_APPLICATION_ORIGINS: props.allowedApplicationOrigins?.join(",") ?? "",
+      ALLOWED_APPLICATION_ORIGINS:
+        props.allowedApplicationOrigins?.join(",") ?? "",
       LOG_LEVEL: props.logLevel ?? "INFO",
     };
     if (props.magicLink) {
@@ -406,7 +407,8 @@ export class Passwordless extends Construct {
     });
     const verifyAuthChallengeResponseEnvironment: Record<string, string> = {
       ALLOWED_ORIGINS: props.allowedOrigins?.join(",") ?? "",
-      ALLOWED_APPLICATION_ORIGINS: props.allowedApplicationOrigins?.join(",") ?? "",
+      ALLOWED_APPLICATION_ORIGINS:
+        props.allowedApplicationOrigins?.join(",") ?? "",
       LOG_LEVEL: props.logLevel ?? "INFO",
     };
     if (props.magicLink) {
@@ -685,7 +687,8 @@ export class Passwordless extends Construct {
             ALLOWED_RELYING_PARTY_IDS:
               props.fido2.allowedRelyingPartyIds.join(",") ?? "",
             ALLOWED_ORIGINS: props.allowedOrigins?.join(",") ?? "",
-            ALLOWED_APPLICATION_ORIGINS: props.allowedApplicationOrigins?.join(",") ?? "",
+            ALLOWED_APPLICATION_ORIGINS:
+              props.allowedApplicationOrigins?.join(",") ?? "",
             ATTESTATION: props.fido2.attestation ?? "none",
             USER_VERIFICATION: props.fido2.userVerification ?? "required",
             AUTHENTICATOR_ATTACHMENT: props.fido2.authenticatorAttachment ?? "",

--- a/cdk/lib/cognito-passwordless.ts
+++ b/cdk/lib/cognito-passwordless.ts
@@ -58,7 +58,7 @@ export class Passwordless extends Construct {
        */
       allowedOrigins?: string[];
       /**
-       * Probably write something
+       * The non web-app origins that will be allowed to authenticate via FIDO2. These may include origins which are not URLs.
        */
       allowedApplicationOrigins?: string[]
       /**


### PR DESCRIPTION
*Issue #:* N/A

*Description of changes:*
Adds a new environment variable and logic for handling origins that are not proper URLs (such as those used by Android apps).

The reason for this change is due to android apps sending `android:apk-key-hash:some_hash` instead of a URL. Currently the origin passed by the client is converted to a URL object which will fail with non-url origins. This behaviour is explained in the webauthn spec [here](https://www.w3.org/TR/webauthn-3/#sctn-validating-origin)

> A web application with a companion native application might allow origin to be an operating system dependent identifier for the native application. For example, such a Relying Party might require that origin exactly equals some element of the list ["https://example.org", "example-os:appid:204ffa1a5af110ac483f131a1bef8a841a7adb0d8d135908bbd964ed05d2653b"].

This PR aims to avoid changing the current behaviour with allowedOrigins and adds this as an extra feature.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
