### PR TITLE
fix bug that required fido2 config object to be passed for Config

### DIFF
--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -697,7 +697,7 @@ function _useLocalUserCache() {
     (user: StoredUser): "YES" | "NO" | "ASK" | "INDETERMINATE" => {
       const { fido2 } = configure();
       if (!fido2) {
-        throw new Error("Missing Fido2 config");
+        return "NO";
       }
       if (hasFido2Credentials === undefined) {
         return "INDETERMINATE";


### PR DESCRIPTION
resolves https://github.com/aws-samples/amazon-cognito-passwordless-auth/issues/128

Sure. I feel if `fido2` isn't defined, `determineFido` can just return `"NO"`. Perhaps there are downstream effects I'm not aware of but seems simplest to me
