### PR TITLE
Fix: removes dead code from define-auth-challenge fido2response

### DIFF
--- a/cdk/custom-auth/define-auth-challenge.ts
+++ b/cdk/custom-auth/define-auth-challenge.ts
@@ -84,9 +84,6 @@ function handleFido2Response(event: DefineAuthChallengeTriggerEvent) {
   const lastResponse = event.request.session.slice(-1)[0];
   if (lastResponse.challengeResult === true) {
     return allow(event);
-  } else if (countAttempts(event, false) === 0) {
-    logger.info("No challenge yet, creating one ...");
-    return customChallenge(event);
   }
   return deny(event, "Failed to authenticate with FIDO2");
 }


### PR DESCRIPTION
*Issue [130](https://github.com/aws-samples/amazon-cognito-passwordless-auth/issues/130), if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
