### PR TITLE
Fix for "TIMESTAMP format" error

### DIFF
--- a/client/srp.ts
+++ b/client/srp.ts
@@ -228,7 +228,7 @@ function arrayBufferToBigInt(arrBuf: ArrayBuffer) {
 }
 
 function formatDate(d: Date) {
-  const parts = new Intl.DateTimeFormat("en-US", {
+  const parts = new Intl.DateTimeFormat("en-u-hc-h23", {
     weekday: "short",
     year: "numeric",
     month: "short",


### PR DESCRIPTION
*Issue: #145*

*Description of changes:*

Fixes the timestamp formatting code so that it doesn't generate "24" as an hour.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
