### PR TITLE
Format n and e in JWK as Base64url

### DIFF
--- a/cdk/custom-auth/fido2-credentials-api.ts
+++ b/cdk/custom-auth/fido2-credentials-api.ts
@@ -803,8 +803,8 @@ function decodeCredentialPublicKey(credentialPublicKey: Buffer) {
         alg: algName,
         kid,
         kty: ktyName,
-        n,
-        e,
+        n: n.toString("base64url"),
+        e: e.toString("base64url"),
       };
       return jwk;
     } else {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Support RSA public keys, by ensuring the is JWK stored with n and e in base64url format, not buffer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
