### PR TITLE
WIP: Enforce MIN_SECONDS_BETWEEN for successful authentications

### DIFF
--- a/cdk/custom-auth/magic-link.ts
+++ b/cdk/custom-auth/magic-link.ts
@@ -357,12 +357,13 @@ async function verifyMagicLink(
   // is performed and no item is returned.
   let dbItem: Record<string, unknown> | undefined = undefined;
   try {
+    const salt = requireConfig("salt");
     ({ Attributes: dbItem } = await ddbDocClient.send(
       new UpdateCommand({
         TableName: requireConfig("dynamodbSecretsTableName"),
         Key: {
           userNameHash: createHash("sha256")
-            .update(requireConfig("salt"))
+            .update(salt)
             .end(userName)
             .digest(),
         },
@@ -376,7 +377,7 @@ async function verifyMagicLink(
         },
         ExpressionAttributeValues: {
           ":signatureHash": createHash("sha256")
-            .update(requireConfig("salt"))
+            .update(salt)
             .end(signature)
             .digest(),
           ":used": true,

--- a/cdk/custom-auth/magic-link.ts
+++ b/cdk/custom-auth/magic-link.ts
@@ -390,6 +390,10 @@ async function verifyMagicLink(
     logger.error("Attempt to use magic link more than once");
     return false;
   }
+  if (!dbItem.exp || typeof dbItem.exp !== "number" || dbItem.exp < Date.now() / 1000) {
+    logger.error("Magic link expired!");
+    return false;
+  }
   if (!dbItem.kmsKeyId || typeof dbItem.kmsKeyId !== "string") {
     throw new Error("Failed to determine KMS Key ID");
   }
@@ -414,10 +418,6 @@ async function verifyMagicLink(
   logger.debug("Checking message:", parsed);
   if (parsed.userName !== userName) {
     logger.error("Different userName!");
-    return false;
-  }
-  if (parsed.exp < Date.now() / 1000) {
-    logger.error("Magic link expired!");
     return false;
   }
   if (parsed.exp !== dbItem.exp || parsed.iat !== dbItem.iat) {

--- a/cdk/custom-auth/magic-link.ts
+++ b/cdk/custom-auth/magic-link.ts
@@ -392,7 +392,7 @@ async function verifyMagicLink(
   }
   assertIsItem(dbItem);
   if (dbItem.exp < Date.now() / 1000) {
-    logger.error("Magic link expired!");
+    logger.error("Magic link expired");
     return false;
   }
   publicKeys[dbItem.kmsKeyId] ??= await downloadPublicKey(dbItem.kmsKeyId);
@@ -415,7 +415,7 @@ async function verifyMagicLink(
   assertIsMessage(parsed);
   logger.debug("Checking message:", parsed);
   if (parsed.userName !== userName) {
-    logger.error("Different userName!");
+    logger.error("Username mismatch");
     return false;
   }
   if (parsed.exp !== dbItem.exp || parsed.iat !== dbItem.iat) {


### PR DESCRIPTION
*Issue #175*

*Description of changes:*

Enforces `MIN_SECONDS_BETWEEN` in both cases by creating an `used` flag for each magic link.

Reorder magic link validation. Checks expiration before anything.

Validate all fields stored in `DynamoDB`.