### PR TITLE
Ask either cognitoIdpEndpoint or userPoolId

### DIFF
--- a/client/config.ts
+++ b/client/config.ts
@@ -92,11 +92,21 @@ export type ConfigWithDefaults = Config &
     Pick<Config, "storage" | "crypto" | "fetch" | "location" | "history">
   >;
 
+type ConfigInput = Omit<Config, "cognitoIdpEndpoint"> &
+  Partial<Pick<Config, "cognitoIdpEndpoint">>;
 let config_: ConfigWithDefaults | undefined = undefined;
-export function configure(config?: Config) {
+export function configure(config?: ConfigInput) {
   if (config) {
+    const cognitoIdpEndpoint =
+      config.cognitoIdpEndpoint || config.userPoolId?.split("_")[0];
+    if (!cognitoIdpEndpoint) {
+      throw new Error(
+        "Invalid configuration provided: either cognitoIdpEndpoint or userPoolId must be provided"
+      );
+    }
     config_ = {
       ...config,
+      cognitoIdpEndpoint,
       crypto: config.crypto ?? Defaults.crypto,
       storage: config.storage ?? Defaults.storage,
       fetch: config.fetch ?? Defaults.fetch,


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Don't force users to provide cognitoIdpEndpoint if they already provide user pool id.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
