### PR TITLE
feat: improve error reporting for invalid magic links

### DIFF
--- a/client/magic-link.ts
+++ b/client/magic-link.ts
@@ -134,7 +134,8 @@ function checkCurrentLocationForSignInLink() {
     debug?.("Magic link header parsed:", message);
     assertIsMessage(message);
   } catch (err) {
-    debug?.("Ignoring invalid fragment identifier");
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    debug?.(`Ignoring invalid fragment identifier: ${errorMessage}`);
     return;
   }
   if (!message.userName || typeof message.userName !== "string") {
@@ -168,7 +169,9 @@ function assertIsMessage(
     !("iat" in msg) ||
     typeof msg.iat !== "number"
   ) {
-    throw new Error("Invalid magic link");
+    throw new Error(
+      "Invalid magic link, expecting exp, iat, and userName to be present"
+    );
   }
 }
 


### PR DESCRIPTION
### Overview

This PR enhances error visibility for invalid magic link handling in the UI. Currently, an invalid magic link would throw a generic error message `Ignoring invalid fragment identifier`, which provided minimal context and made debugging challenging. 


<img width="562" alt="Screenshot 2024-11-07 at 12 32 18" src="https://github.com/user-attachments/assets/4f20555c-8b52-47d1-9a97-6584907604a4">

It took us sometime to identify the issue and this PR introduces more descriptive error handling to help quickly understand the root cause with invalid magic links.

Results:

<img width="821" alt="Screenshot 2024-11-07 at 12 53 53" src="https://github.com/user-attachments/assets/07070f7f-8c3d-41b2-85cb-8f4f6ce6bc22">

