### PR TITLE
Add OTP (Software MFA Token) Support.

### DIFF
--- a/client/cognito-api.ts
+++ b/client/cognito-api.ts
@@ -30,7 +30,8 @@ type ChallengeName =
   | "CUSTOM_CHALLENGE"
   | "PASSWORD_VERIFIER"
   | "SMS_MFA"
-  | "NEW_PASSWORD_REQUIRED";
+  | "NEW_PASSWORD_REQUIRED"
+  | "SOFTWARE_TOKEN_MFA";
 
 interface ChallengeResponse {
   ChallengeName: ChallengeName;
@@ -648,6 +649,7 @@ export async function handleAuthResponse({
   authResponse,
   username,
   smsMfaCode,
+  otpMfaCode,
   newPassword,
   customChallengeAnswer,
   clientMetadata,
@@ -659,6 +661,7 @@ export async function handleAuthResponse({
    */
   username: string;
   smsMfaCode?: () => Promise<string>;
+  otpMfaCode?: () => Promise<string>;
   newPassword?: () => Promise<string>;
   customChallengeAnswer?: () => Promise<string>;
   clientMetadata?: Record<string, string>;
@@ -688,6 +691,9 @@ export async function handleAuthResponse({
       if (!customChallengeAnswer)
         throw new Error("Missing custom challenge answer");
       responseParameters.ANSWER = await customChallengeAnswer();
+    } else if (authResponse.ChallengeName === "SOFTWARE_TOKEN_MFA") {
+      if (!otpMfaCode) throw new Error("Missing Software MFA Code");
+      responseParameters.SOFTWARE_TOKEN_MFA_CODE = await otpMfaCode();
     } else {
       throw new Error(`Unsupported challenge: ${authResponse.ChallengeName}`);
     }

--- a/client/plaintext.ts
+++ b/client/plaintext.ts
@@ -21,6 +21,7 @@ export function authenticateWithPlaintextPassword({
   username,
   password,
   smsMfaCode,
+  otpMfaCode,
   newPassword,
   tokensCb,
   statusCb,
@@ -32,6 +33,7 @@ export function authenticateWithPlaintextPassword({
   username: string;
   password: string;
   smsMfaCode?: () => Promise<string>;
+  otpMfaCode?: () => Promise<string>;
   newPassword?: () => Promise<string>;
   tokensCb?: (tokens: TokensFromSignIn) => void | Promise<void>;
   statusCb?: (status: BusyState | IdleState) => void;
@@ -57,6 +59,7 @@ export function authenticateWithPlaintextPassword({
         authResponse,
         username,
         smsMfaCode,
+        otpMfaCode,
         newPassword,
         clientMetadata,
         abort: abort.signal,

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -501,6 +501,7 @@ function _usePasswordless() {
       username,
       password,
       smsMfaCode,
+      otpMfaCode,
       clientMetadata,
     }: {
       /**
@@ -509,6 +510,7 @@ function _usePasswordless() {
       username: string;
       password: string;
       smsMfaCode?: () => Promise<string>;
+      otpMfaCode?: () => Promise<string>;
       clientMetadata?: Record<string, string>;
     }) => {
       setLastError(undefined);
@@ -516,6 +518,7 @@ function _usePasswordless() {
         username,
         password,
         smsMfaCode,
+        otpMfaCode,
         clientMetadata,
         statusCb: setSigninInStatus,
         tokensCb: (tokens) => storeTokens(tokens).then(() => setTokens(tokens)),
@@ -528,6 +531,7 @@ function _usePasswordless() {
       username,
       password,
       smsMfaCode,
+      otpMfaCode,
       clientMetadata,
     }: {
       /**
@@ -536,6 +540,7 @@ function _usePasswordless() {
       username: string;
       password: string;
       smsMfaCode?: () => Promise<string>;
+      otpMfaCode?: () => Promise<string>;
       clientMetadata?: Record<string, string>;
     }) => {
       setLastError(undefined);
@@ -543,6 +548,7 @@ function _usePasswordless() {
         username,
         password,
         smsMfaCode,
+        otpMfaCode,
         clientMetadata,
         statusCb: setSigninInStatus,
         tokensCb: (tokens) => storeTokens(tokens).then(() => setTokens(tokens)),

--- a/client/srp.ts
+++ b/client/srp.ts
@@ -255,6 +255,7 @@ export function authenticateWithSRP({
   username,
   password,
   smsMfaCode,
+  otpMfaCode,
   newPassword,
   customChallengeAnswer,
   authflow = "USER_SRP_AUTH",
@@ -268,6 +269,7 @@ export function authenticateWithSRP({
   username: string;
   password: string;
   smsMfaCode?: () => Promise<string>;
+  otpMfaCode?: () => Promise<string>;
   newPassword?: () => Promise<string>;
   customChallengeAnswer?: () => Promise<string>;
   authflow?: "USER_SRP_AUTH" | "CUSTOM_AUTH";
@@ -335,6 +337,7 @@ export function authenticateWithSRP({
         authResponse: authResult,
         username,
         smsMfaCode,
+        otpMfaCode,
         newPassword,
         customChallengeAnswer,
         clientMetadata,


### PR DESCRIPTION
**Issue #, if available:**
N/A
**Description of changes:**
I added support for the SOFTWARE_TOKEN_MFA authentication mode for plaintext authentication and SRP authentication. This was specific to our use-case, but I believe it is a helpful addition so I am making an upstream PR.

This is my first contribution to this AWS repository, so please let me know if I need to make additional changes.

The exact changes are as follows:
 - Added a `otpMfaCode` parameter to the authenticateWithPlaintextPassword and authenticateWithSrp functions.
 - Added support for the `SOFTWARE_TOKEN_MFA` challenge.

This change was made as part of the ĀYŌDÈ organization.

**Testing:**
I tested both the plaintext authentication and srp authentication modes with the OTP authentication callback. I also ran `eslint` and `prettier` on the codebase.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
