### PR TITLE
fix: order of types and default in exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
       "types": "./index.d.ts"
     },
     "./cdk": {
-      "default": "./dist/cdk/lib/cognito-passwordless.js",
-      "types": "./cdk.d.ts"
+      "types": "./cdk.d.ts",
+      "default": "./dist/cdk/lib/cognito-passwordless.js"
     },
     "./cognito-api": {
       "import": "./dist/client/cognito-api.js",


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Changed the order of `types` and `default` in `exports`, so that `types` comes before `default`. This silences an `esbuild` warning.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
