### PR TITLE
Update custom magic link functions to accept user attributes

### DIFF
--- a/cdk/custom-auth/magic-link.ts
+++ b/cdk/custom-auth/magic-link.ts
@@ -41,6 +41,7 @@ import {
   UserFacingError,
   handleConditionalCheckFailedException,
 } from "./common.js";
+import { StringMap } from "aws-lambda/trigger/cognito-user-pool-trigger/_common";
 
 let config = {
   /** Should Magic Link sign-in be enabled? If set to false, clients cannot sign-in with magic links (an error is shown instead when they request a magic link) */
@@ -143,6 +144,7 @@ async function createEmailContent({
   secretLoginLink,
 }: {
   secretLoginLink: string;
+  userAttributes: StringMap;
 }) {
   return {
     html: {
@@ -164,7 +166,7 @@ async function createEmailContent({
 
 async function sendEmailWithLink({
   emailAddress,
-  content,
+  content
 }: {
   emailAddress: string;
   content: {
@@ -172,6 +174,7 @@ async function sendEmailWithLink({
     text: { charSet: string; data: string };
     subject: { charSet: string; data: string };
   };
+  userAttributes: StringMap;
 }) {
   await ses
     .send(
@@ -292,7 +295,9 @@ async function createAndSendMagicLink(
     emailAddress: event.request.userAttributes.email,
     content: await config.contentCreator.call(undefined, {
       secretLoginLink,
+      userAttributes: event.request.userAttributes,
     }),
+    userAttributes: event.request.userAttributes
   });
   logger.debug("Magic link sent!");
 }

--- a/cdk/custom-auth/magic-link.ts
+++ b/cdk/custom-auth/magic-link.ts
@@ -41,7 +41,6 @@ import {
   UserFacingError,
   handleConditionalCheckFailedException,
 } from "./common.js";
-import { StringMap } from "aws-lambda/trigger/cognito-user-pool-trigger/_common";
 
 let config = {
   /** Should Magic Link sign-in be enabled? If set to false, clients cannot sign-in with magic links (an error is shown instead when they request a magic link) */
@@ -144,7 +143,7 @@ async function createEmailContent({
   secretLoginLink,
 }: {
   secretLoginLink: string;
-  userAttributes: StringMap;
+  userAttributes: { [name: string]: string };
 }) {
   return {
     html: {
@@ -174,7 +173,7 @@ async function sendEmailWithLink({
     text: { charSet: string; data: string };
     subject: { charSet: string; data: string };
   };
-  userAttributes: StringMap;
+  userAttributes: { [name: string]: string };
 }) {
   await ses
     .send(

--- a/cdk/custom-auth/magic-link.ts
+++ b/cdk/custom-auth/magic-link.ts
@@ -166,7 +166,7 @@ async function createEmailContent({
 
 async function sendEmailWithLink({
   emailAddress,
-  content
+  content,
 }: {
   emailAddress: string;
   content: {
@@ -297,7 +297,7 @@ async function createAndSendMagicLink(
       secretLoginLink,
       userAttributes: event.request.userAttributes,
     }),
-    userAttributes: event.request.userAttributes
+    userAttributes: event.request.userAttributes,
   });
   logger.debug("Magic link sent!");
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Updates the `createEmailContent` and `sendEmailWithLink` to accept the user attributes from cognito as additional parameters.

This is to allow customising the email content and sending based on the users details, such as branding.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
