### PR TITLE
Fix decoding Attestation auth data with extentions

### DIFF
--- a/cdk/custom-auth/fido2-credentials-api.ts
+++ b/cdk/custom-auth/fido2-credentials-api.ts
@@ -26,7 +26,7 @@ import {
   UpdateCommand,
   PutCommand,
 } from "@aws-sdk/lib-dynamodb";
-import { decodeFirstSync } from "cbor";
+import { decodeAllSync, decodeFirstSync } from "cbor";
 import {
   determineUserHandle,
   logger,
@@ -870,8 +870,9 @@ function parseBody(event: { body?: string | null; isBase64Encoded: boolean }) {
 
 function cborDecode(b: Buffer, name: string) {
   try {
+    const decoded = decodeAllSync(b);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    return decodeFirstSync(b) as unknown;
+    return decoded[0] as unknown
   } catch (err) {
     logger.error(err);
     throw new UserFacingError(`Invalid ${name}`);

--- a/cdk/custom-auth/fido2-credentials-api.ts
+++ b/cdk/custom-auth/fido2-credentials-api.ts
@@ -26,7 +26,7 @@ import {
   UpdateCommand,
   PutCommand,
 } from "@aws-sdk/lib-dynamodb";
-import { decodeAllSync, decodeFirstSync } from "cbor";
+import { decodeAllSync } from "cbor";
 import {
   determineUserHandle,
   logger,
@@ -872,7 +872,7 @@ function cborDecode(b: Buffer, name: string) {
   try {
     const decoded = decodeAllSync(b);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    return decoded[0] as unknown
+    return decoded[0] as unknown;
   } catch (err) {
     logger.error(err);
     throw new UserFacingError(`Invalid ${name}`);


### PR DESCRIPTION
*Issue #, if available:*

This fixes an issue similar to this one: https://github.com/cedarcode/webauthn-ruby/issues/107

Samsung passkeys seem to pass an extension
```
{
    "hmac_secret": true
}
```

which is causing the cbor decoder to fail as there's more data than expected.

The error we are seeing in AWS Cloudwatch is:
`Unexpected data: 0xa1 at decodeFirstSync (file:///var/task/index.mjs:1830:19) at cborDecode (file:///var/task/index.mjs:4541:44) at decodeCredentialPublicKey`

This change decodes all the data to prevent this, and then returns the first decoded object to replicate the existing returned data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
