### PR TITLE
fix README-REACT.md

### DIFF
--- a/client/react/README-REACT.md
+++ b/client/react/README-REACT.md
@@ -158,7 +158,7 @@ To use the library, you need to first import and configure it, and then wrap you
 In your web app's entrypoint (e.g. `main.tsx`)
 
 ```javascript
-import { Passwordless } from "amazon-cognito-passwordless-auth/react";
+import { Passwordless } from "amazon-cognito-passwordless-auth";
 
 Passwordless.configure({
   cognitoIdpEndpoint: "eu-west-1", // you can also use the full endpoint URL, potentially to use a proxy


### PR DESCRIPTION
in the example the component was imported which does not have function configure.

*Description of changes:*
The documentation was falsely importing the component from the react sub path. this fixes the documentation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
